### PR TITLE
Fix: 배포 시 빌드 모드 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies and build
         run: |
           npm install
-          npm run build
+          npm run build -- --mode production
 
       # 4. 빌드 파일 전송 (배포 파일 업로드)
       - name: Copy build files


### PR DESCRIPTION
## 배경
- VITE 프로젝트는 환경에 따른 환경 변수 적용 가능
  - `.env.development` -> 개발 환경
  - `.env.production` -> 배포 환경
- 배포 환경에서 `.env.production`이 제대로 적용되지 않는 문제 발견

## 작업 사항
- `cd.yml` 파일에서 빌드 시 모드 추가 (dcec6368387523feb78294995ab73fa3bbcf046f)
```yaml
# npm run build
npm run build -- --mode production
```
