### PR TITLE
Feature: AccessToken 전역 저장 및 닉네임 등록 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.7.9",
+        "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^7.1.1",
@@ -3611,7 +3612,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3886,7 +3886,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -3933,8 +3932,7 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "axios": "^1.7.9",
+    "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.1.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,10 +8,12 @@ import Transactions from "@/pages/Transactions";
 import GlobalStyles from "@/GlobalStyles";
 import KakaoRedirect from "@/components/sign-in/KakaoRedirect";
 import NaverRedirect from "@/components/sign-in/NaverRedirect";
+import SignUp from "@/pages/SignUp";
+import { AuthProvider } from "@/contexts/AuthProvider";
 
 const App = () => {
   return (
-    <>
+    <AuthProvider>
       <GlobalStyles />
       <Router>
         <Routes>
@@ -19,6 +21,7 @@ const App = () => {
           <Route path="/signin" element={<SignIn />} />
           <Route path="/login/oauth2/code/kakao" element={<KakaoRedirect />} />
           <Route path="/login/oauth2/code/naver" element={<NaverRedirect />} />
+          <Route path="/signup" element={<SignUp />} />
 
           {/* Layout이 적용되는 경로 */}
           <Route path="/" element={<Layout />}>
@@ -36,7 +39,7 @@ const App = () => {
           </Route>
         </Routes>
       </Router>
-    </>
+    </AuthProvider>
   );
 };
 

--- a/src/api/authApi.jsx
+++ b/src/api/authApi.jsx
@@ -1,0 +1,34 @@
+import axios from "axios";
+import { baseUrl } from "@/config/Env";
+
+const authApi = axios.create({
+  baseURL: baseUrl,
+  withCredentials: true,
+});
+
+authApi.interceptors.request.use(
+  (config) => {
+    const token = localStorage.getItem("accessToken");
+
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
+authApi.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response && error.response.status === 401) {
+      console.error("인증 오류: 토큰이 유효하지 않거나 만료되었습니다.");
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default authApi;

--- a/src/api/axios.jsx
+++ b/src/api/axios.jsx
@@ -1,9 +1,0 @@
-import axios from "axios";
-import { baseUrl } from "../config/Env";
-
-const api = axios.create({
-  baseURL: baseUrl,
-  withCredentials: true,
-});
-
-export default api;

--- a/src/api/noAuthApi.jsx
+++ b/src/api/noAuthApi.jsx
@@ -1,0 +1,9 @@
+import axios from "axios";
+import { baseUrl } from "@/config/Env";
+
+const noAuthapi = axios.create({
+  baseURL: baseUrl,
+  withCredentials: true,
+});
+
+export default noAuthapi;

--- a/src/api/sign-in/socialSignIn.jsx
+++ b/src/api/sign-in/socialSignIn.jsx
@@ -1,8 +1,8 @@
-import api from "../axios";
+import noAuthapi from "@/api/noAuthApi";
 
 const socialSignIn = async (platform, code) => {
   try {
-    const response = await api.post(`auth/sign-in/${platform}`, { code });
+    const response = await noAuthapi.post(`auth/sign-in/${platform}`, { code });
     return response.data;
   } catch (error) {
     console.error("API 요청 중 오류 발생", error);

--- a/src/api/sign-up/postNickname.jsx
+++ b/src/api/sign-up/postNickname.jsx
@@ -1,0 +1,22 @@
+import authApi from "@/api/authApi";
+
+const postNickname = async (nickname) => {
+  try {
+    const response = await authApi.post(`auth/sign-up`, { nickname });
+    return response.data;
+  } catch (error) {
+    console.error("API 요청 중 오류 발생", error);
+    if (error.response) {
+      console.error("응답 오류:", error.response.data);
+      throw new Error("서버 오류 발생");
+    } else if (error.request) {
+      console.error("네트워크 오류 또는 서버 응답 없음");
+      throw new Error("네트워크 오류 또는 서버 응답 없음");
+    } else {
+      console.error("요청 설정 오류:", error.message);
+      throw new Error("요청 설정 오류");
+    }
+  }
+};
+
+export default postNickname;

--- a/src/components/sign-in/KakaoRedirect.jsx
+++ b/src/components/sign-in/KakaoRedirect.jsx
@@ -1,9 +1,32 @@
-import { useEffect } from "react";
-import { useLocation } from "react-router-dom";
+import { useCallback, useEffect } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useAuth } from "@/contexts/useAuth";
 import socialSignIn from "@/api/sign-in/socialSignIn";
 
 const KakaoRedirect = () => {
   const location = useLocation();
+  const navigate = useNavigate();
+  const { login } = useAuth();
+
+  const fetchKakaoAccessToken = useCallback(
+    async (code) => {
+      try {
+        const response = await socialSignIn("KAKAO", code);
+        console.log("카카오 로그인 성공", response);
+
+        login({ token: response.data.accessToken });
+
+        if (response.data.isRegistered) {
+          navigate("/");
+        } else {
+          navigate("/signup");
+        }
+      } catch (error) {
+        console.error("카카오 로그인 중 오류 발생:", error.message);
+      }
+    },
+    [navigate, login]
+  );
 
   useEffect(() => {
     const queryPrams = new URLSearchParams(location.search);
@@ -12,16 +35,7 @@ const KakaoRedirect = () => {
     if (code) {
       fetchKakaoAccessToken(code);
     }
-  }, [location]);
-
-  const fetchKakaoAccessToken = async (code) => {
-    try {
-      const response = await socialSignIn("KAKAO", code);
-      console.log("카카오 로그인 성공", response);
-    } catch (error) {
-      console.error("카카오 로그인 중 오류 발생:", error.message);
-    }
-  };
+  }, [location, fetchKakaoAccessToken]);
 };
 
 export default KakaoRedirect;

--- a/src/components/sign-in/NaverRedirect.jsx
+++ b/src/components/sign-in/NaverRedirect.jsx
@@ -1,9 +1,32 @@
-import { useEffect } from "react";
-import { useLocation } from "react-router-dom";
+import { useCallback, useEffect } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import socialSignIn from "@/api/sign-in/socialSignIn";
+import { useAuth } from "@/contexts/useAuth";
 
 const NaverRedirect = () => {
   const location = useLocation();
+  const navigate = useNavigate();
+  const { login } = useAuth();
+
+  const fetchNaverAccessToken = useCallback(
+    async (code) => {
+      try {
+        const response = await socialSignIn("NAVER", code);
+        console.log("네이버 로그인 성공", response);
+
+        login({ token: response.data.accessToken });
+
+        if (response.data.isRegistered) {
+          navigate("/");
+        } else {
+          navigate("/signup");
+        }
+      } catch (error) {
+        console.error("네이버 로그인 중 오류 발생:", error.message);
+      }
+    },
+    [navigate, login]
+  );
 
   useEffect(() => {
     const queryPrams = new URLSearchParams(location.search);
@@ -12,16 +35,7 @@ const NaverRedirect = () => {
     if (code) {
       fetchNaverAccessToken(code);
     }
-  }, [location]);
-
-  const fetchNaverAccessToken = async (code) => {
-    try {
-      const response = await socialSignIn("NAVER", code);
-      console.log("네이버 로그인 성공", response);
-    } catch (error) {
-      console.error("네이버 로그인 중 오류 발생:", error.message);
-    }
-  };
+  }, [location, fetchNaverAccessToken]);
 };
 
 export default NaverRedirect;

--- a/src/components/sign-up/SignUpForm.jsx
+++ b/src/components/sign-up/SignUpForm.jsx
@@ -1,0 +1,220 @@
+import styled from "styled-components";
+import MuzusiLogo from "@/assets/logo/MuzusiLogo.png";
+import { useState } from "react";
+import postNickname from "../../api/sign-up/postNickname";
+import { useNavigate } from "react-router-dom";
+
+const SignUpForm = () => {
+  const navigate = useNavigate();
+
+  const [nickname, setNickname] = useState("");
+  const [available, setAvailable] = useState(
+    "2~8자의 한글, 영문, 숫자(공백, 특수문자 제외)"
+  );
+  const [error, setError] = useState("");
+
+  const handleInputChange = (e) => {
+    const value = e.target.value;
+    setNickname(value);
+
+    const regex = /^[a-zA-Z0-9ㄱ-ㅎ|ㅏ-ㅣ|가-힣]{2,8}$/;
+    if (regex.test(value)) {
+      setAvailable("사용 가능한 닉네임입니다.");
+      setError("");
+    } else if (!value) {
+      setAvailable("2~8자의 한글, 영문, 숫자(공백, 특수문자 제외)");
+      setError("");
+    } else {
+      setAvailable("");
+      setError("닉네임 형식을 확인해주세요.");
+    }
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!error && nickname.length > 0) {
+      try {
+        const response = await postNickname(nickname);
+        if (response.code === 200) {
+          console.log("닉네임 등록 성공", response);
+          alert("닉네임 등록이 완료되었습니다.");
+          navigate("/");
+        } else {
+          console.error("닉네임 등록 실패", response);
+          setError("닉네임 등록 중 문제가 발생했습니다. 다시 시도해주세요.");
+        }
+      } catch (apiError) {
+        console.error("닉네임 등록 실패", apiError);
+        setError("닉네임 등록 중 문제가 발생했습니다. 다시 시도해주세요.");
+      }
+    } else {
+      setError("닉네임 형식을 확인해주세요.");
+      setAvailable("");
+    }
+  };
+
+  return (
+    <SignUpFormContainer>
+      <SignUpFormLogo href="/">
+        <SignUpFormLogoImg
+          alt="무주시"
+          loading="lazy"
+          decoding="async"
+          src={MuzusiLogo}
+        />
+      </SignUpFormLogo>
+      <SignUpText>무자본으로 시작하는 주식 시뮬레이션</SignUpText>
+
+      <NicknameForm onSubmit={handleSubmit}>
+        <NicknameText>닉네임</NicknameText>
+        <NicknameInput
+          value={nickname}
+          onChange={handleInputChange}
+          $hasError={!!error}
+          placeholder="사용하실 닉네임을 입력해주세요."
+        />
+        {available && <AvailableText>{available}</AvailableText>}
+        {error && <ErrorText>{error}</ErrorText>}
+        <NicknameBtns>
+          <SubmitBtn type="submit">확인</SubmitBtn>
+          <SkipBtnContainer>
+            <SkipBtn href="/">건너뛰기&gt;</SkipBtn>
+          </SkipBtnContainer>
+        </NicknameBtns>
+      </NicknameForm>
+    </SignUpFormContainer>
+  );
+};
+
+export default SignUpForm;
+
+const SignUpFormContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  width: 600px;
+  height: 450px;
+  flex-shrink: 0;
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0px 10px 60px 2px rgba(0, 0, 0, 0.1);
+  margin: auto;
+  padding: 80px 50px 60px 50px;
+`;
+
+const SignUpText = styled.div`
+  color: #747474;
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
+  text-align: center;
+  margin: 0 auto;
+`;
+
+const SignUpFormLogo = styled.a`
+  margin: 0 auto;
+`;
+
+const SignUpFormLogoImg = styled.img`
+  width: 200px;
+  height: auto;
+  border: none;
+  background: none;
+`;
+
+const NicknameText = styled.div`
+  width: 100%;
+  text-align: left;
+  font-size: 20px;
+  font-weight: 600;
+  padding: 5px;
+`;
+
+const NicknameForm = styled.form`
+  display: flex;
+  width: 80%;
+  flex-direction: column;
+  align-items: center;
+  margin: 0 auto;
+`;
+
+const NicknameInput = styled.input`
+  width: 100%;
+  height: 60px;
+  padding: 8px 12px;
+  border: 2px solid ${({ $hasError }) => ($hasError ? "#FF0000" : "#000")};
+  border-radius: 8px;
+  font-size: 20px;
+  font-weight: 600;
+  font-family: pretendard;
+  outline: none;
+  &:focus {
+    border-color: ${({ $hasError }) => ($hasError ? "#FF0000" : "#000")};
+  }
+  &::placeholder {
+    color: #aaaaaa;
+    font-weight: 400;
+  }
+`;
+
+const AvailableText = styled.div`
+  width: 100%;
+  font-size: 14px;
+  padding-left: 5px;
+`;
+
+const ErrorText = styled.div`
+  width: 100%;
+  color: #ff0000;
+  font-size: 14px;
+  padding-left: 5px;
+`;
+
+const NicknameBtns = styled.div`
+  width: 100%;
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+`;
+
+const SubmitBtn = styled.button`
+  width: 100%;
+  height: 50px;
+  background-color: #000;
+  color: #fff;
+  border: 2px solid #fff;
+  border-radius: 10px;
+  font-size: 16px;
+  font-weight: 500;
+  font-family: pretendard;
+  transition: 0.2s;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #fff;
+    color: #000;
+    border-color: #000;
+  }
+`;
+
+const SkipBtnContainer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: end;
+  padding-right: 5px;
+`;
+
+const SkipBtn = styled.a`
+  text-decoration: none;
+  color: #cccccc;
+  border-radius: 10px;
+  font-size: 16px;
+  font-weight: 500;
+  transition: 0.2s;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,0 +1,5 @@
+import { createContext } from "react";
+
+const AuthContext = createContext();
+
+export default AuthContext;

--- a/src/contexts/AuthProvider.jsx
+++ b/src/contexts/AuthProvider.jsx
@@ -1,0 +1,45 @@
+import { useState, useEffect, useMemo, useCallback } from "react";
+import PropTypes from "prop-types";
+import AuthContext from "@/contexts/AuthContext";
+import {
+  getStoredUser,
+  getStoredToken,
+  saveUserAndToken,
+  clearStorage,
+} from "@/contexts/AuthUtil";
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null);
+  const [accessToken, setAccessToken] = useState(null);
+
+  useEffect(() => {
+    const storedUser = getStoredUser();
+    const storedToken = getStoredToken();
+
+    if (storedUser) setUser(storedUser);
+    if (storedToken) setAccessToken(storedToken);
+  }, []);
+
+  const login = useCallback(({ user, token }) => {
+    setUser(user);
+    setAccessToken(token);
+    saveUserAndToken(user, token);
+  }, []);
+
+  const logout = useCallback(() => {
+    console.log("로그아웃 처리");
+    setUser(null);
+    setAccessToken(null);
+    clearStorage();
+  }, []);
+  const value = useMemo(
+    () => ({ user, accessToken, login, logout }),
+    [user, accessToken, login, logout]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+AuthProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/src/contexts/AuthUtil.jsx
+++ b/src/contexts/AuthUtil.jsx
@@ -1,0 +1,30 @@
+export const getStoredUser = () => {
+  try {
+    const storedUser = localStorage.getItem("user");
+    return storedUser ? JSON.parse(storedUser) : null;
+  } catch (error) {
+    console.error("로컬 스토리지에서 유저 데이터를 파싱하는 중 오류:", error);
+    localStorage.removeItem("user");
+    return null;
+  }
+};
+
+export const getStoredToken = () => {
+  try {
+    return localStorage.getItem("accessToken");
+  } catch (error) {
+    console.error("로컬 스토리지에서 토큰을 읽는 중 오류:", error);
+    localStorage.removeItem("accessToken");
+    return null;
+  }
+};
+
+export const saveUserAndToken = (user, token) => {
+  localStorage.setItem("user", JSON.stringify(user));
+  localStorage.setItem("accessToken", token);
+};
+
+export const clearStorage = () => {
+  localStorage.removeItem("user");
+  localStorage.removeItem("accessToken");
+};

--- a/src/contexts/useAuth.jsx
+++ b/src/contexts/useAuth.jsx
@@ -1,0 +1,10 @@
+import { useContext } from "react";
+import AuthContext from "@/contexts/AuthContext";
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth 불러오기 실패");
+  }
+  return context;
+};

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -1,0 +1,27 @@
+import styled from "styled-components";
+import SignUpForm from "../components/sign-up/SignUpForm";
+
+const SignUp = () => {
+  return (
+    <Container>
+      <ContentContainer>
+        <SignUpForm />
+      </ContentContainer>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  background: linear-gradient(to bottom, #bbbbbb, white);
+  height: 50vh;
+  width: 100%;
+`;
+
+const ContentContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: calc(100% - 56px);
+  height: 100vh;
+`;
+export default SignUp;


### PR DESCRIPTION
## 배경
- #22 
- 로그인 시 AccessToken 전역 저장
- 최초 로그인 시 닉네임 설정

## 작업 사항
- **PropTypes 패키지 설치** (64ae0a4b455cdfddacedd0aa17b7428ef5d07eb6)
- **ContextAPI를 사용한 토큰 전역 저장** (5b17654e597ce2e40dba9ffee43bc0d4fdf2e764)
  - 저장할 정보가 많지 않다고 판단되어 Redux 대신 ContextAPI를 사용했습니다.
- **닉네임 등록 UI 추가** (9c248d1cd92467d8e05c01e104f673c51566933b)
- **권한에 따른 API 객체 분리** (468b26536e5f7fa745dd7ab5a2aecb54bcd26c8c)
- **토큰 전역 저장 로직 추가** (ba72e2af0d3d182daf2a19fcb1a240d83af8f53c)
- **닉네임 등록 API 연결** (a3baa950b7e00ae354b05e70f5dae76274a8eae5)
- **API 객체 분리에 따른 리팩토링** (2385cc6c9562c06988fafee43a703ed4933c2e51)

## 추가 논의
- 전역 저장 구현 -> 회원가입 순으로 해야했는데 순서를 헷갈려 하나의 PR 크기가 좀 커졌습니다. 양해 부탁드립니다.
- 닉네임 등록 UI가 기존 UI 설계에 없던 화면이라 제가 임의대로 구성했습니다. 수정할 부분 있으면 말씀해주세요.
![image](https://github.com/user-attachments/assets/2ee0eb8f-1d52-4b00-9e8c-2b5d82a17edf)

- 로그인 시에 닉네임도 같이 Response로 주시면 토큰과 함께 저장할 수 있을 것 같습니다!
