### PR TITLE
Feature: 닉네임 정보 전역 저장

### DIFF
--- a/src/contexts/AuthProvider.jsx
+++ b/src/contexts/AuthProvider.jsx
@@ -6,6 +6,7 @@ import {
   getStoredToken,
   saveUserAndToken,
   clearStorage,
+  getNicknameFromToken,
 } from "@/contexts/AuthUtil";
 
 export const AuthProvider = ({ children }) => {
@@ -17,13 +18,20 @@ export const AuthProvider = ({ children }) => {
     const storedToken = getStoredToken();
 
     if (storedUser) setUser(storedUser);
-    if (storedToken) setAccessToken(storedToken);
+    if (storedToken) {
+      setAccessToken(storedToken);
+      const nickname = getNicknameFromToken(storedToken);
+      if (nickname) {
+        setUser((prev) => ({ ...prev, nickname }));
+      }
+    }
   }, []);
 
   const login = useCallback(({ user, token }) => {
-    setUser(user);
+    const nickname = getNicknameFromToken(token);
+    setUser({ ...user, nickname });
     setAccessToken(token);
-    saveUserAndToken(user, token);
+    saveUserAndToken({ ...user, nickname }, token);
   }, []);
 
   const logout = useCallback(() => {

--- a/src/contexts/AuthUtil.jsx
+++ b/src/contexts/AuthUtil.jsx
@@ -19,6 +19,29 @@ export const getStoredToken = () => {
   }
 };
 
+export const decodeToken = (token) => {
+  try {
+    const base64Payload = token.split(".")[1];
+    if (!base64Payload) throw new Error("유효하지 않은 토큰 구조");
+    const base64 = base64Payload.replace(/-/g, "+").replace(/_/g, "/");
+    const payload = decodeURIComponent(
+      atob(base64)
+        .split("")
+        .map((c) => `%${c.charCodeAt(0).toString(16).padStart(2, "0")}`)
+        .join("")
+    );
+    return JSON.parse(payload);
+  } catch (error) {
+    console.error("토큰 디코딩 중 오류 발생:", error);
+    return null;
+  }
+};
+
+export const getNicknameFromToken = (token) => {
+  const decoded = decodeToken(token);
+  return decoded ? decoded.nickname : null;
+};
+
 export const saveUserAndToken = (user, token) => {
   localStorage.setItem("user", JSON.stringify(user));
   localStorage.setItem("accessToken", token);

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,5 +1,9 @@
+import { useAuth } from "@/contexts/useAuth";
+
 const Home = () => {
-  return <div>메인 페이지입니다.</div>;
+  const { user } = useAuth();
+
+  return <div>환영합니다, {user?.nickname}님</div>;
 };
 
 export default Home;


### PR DESCRIPTION
## 배경
- 서버에서 닉네임 정보 추가 전송
- AccessToken 디코딩 후 닉네임 정보 전역 저장

## 작업 사항
- AccessToken 디코딩 및 한글 변환 (f62384487327d5aec5f4cb2f3b323f48cae3767e)
- 닉네임 저장 기능 추가 (8de6feef07772887af65150016536a592eff722d)
- 테스트 코드 작성 (838c44d44840639909efcfaf65ef33ba8e8bdc23)

## 추가 논의
- 근데 원래 닉네임을 이런 식으로 넘겨주는 방식도 많이 사용하나요?
