### PR TITLE
Feature: 토큰 재발급 기능 구현

### DIFF
--- a/src/api/authApi.jsx
+++ b/src/api/authApi.jsx
@@ -1,19 +1,40 @@
 import axios from "axios";
 import { baseUrl } from "@/config/Env";
+import { useAuth } from "@/contexts/useAuth";
 
 const authApi = axios.create({
   baseURL: baseUrl,
   withCredentials: true,
 });
 
-export const reissueAccessToken = async () => {
+export const reissueAccessToken = async (logout) => {
   try {
     const response = await authApi.get("/auth/reissue");
-    const { accessToken } = response.data.data;
-    localStorage.setItem("accessToken", accessToken);
-    return accessToken;
+    console.log(response);
+
+    if (response.data.code === 200) {
+      const { accessToken } = response.data.data;
+      localStorage.setItem("accessToken", accessToken);
+      console.log("토큰 재발급 성공", accessToken);
+      return accessToken;
+    }
+    throw new Error("토큰 재발급 오류");
   } catch (error) {
-    console.error("토큰 재발급 오류", error);
+    if (error.response) {
+      if (error.reponse.data.code === "0008") {
+        console.log(error.response.data.message);
+        alert("세션이 만료되었습니다. 다시 로그인해주세요.");
+        logout();
+        return null;
+      }
+      console.error(
+        "토큰 재발급 중 예상치 못한 오류",
+        error.response.data.message || error.message
+      );
+    } else {
+      console.error("네트워크 또는 서버 오류", error);
+    }
+
     throw error;
   }
 };
@@ -36,19 +57,17 @@ authApi.interceptors.response.use(
   (response) => response,
   async (error) => {
     const originalRequest = error.config;
+    const { logout } = useAuth();
 
-    if (
-      error.response &&
-      error.response.status === 401 &&
-      !originalRequest._retry
-    ) {
+    if (error.response.data.code === "0004" && !originalRequest._retry) {
       originalRequest._retry = true;
       try {
-        const newAccessToken = await reissueAccessToken();
+        const newAccessToken = await reissueAccessToken(logout);
         authApi.defaults.headers["Authorization"] = `Bearer ${newAccessToken}`;
         return authApi(originalRequest);
       } catch (error) {
         console.error("토큰 재발급 실패", error);
+        logout();
         return Promise.reject(error);
       }
     }

--- a/src/contexts/AuthProvider.jsx
+++ b/src/contexts/AuthProvider.jsx
@@ -39,7 +39,7 @@ export const AuthProvider = ({ children }) => {
     setUser(null);
     setAccessToken(null);
     clearStorage();
-    window.location.herf = "/home";
+    window.location.herf = "/";
   }, []);
 
   const value = useMemo(

--- a/src/contexts/AuthProvider.jsx
+++ b/src/contexts/AuthProvider.jsx
@@ -39,7 +39,9 @@ export const AuthProvider = ({ children }) => {
     setUser(null);
     setAccessToken(null);
     clearStorage();
+    window.location.herf = "/home";
   }, []);
+
   const value = useMemo(
     () => ({ user, accessToken, login, logout }),
     [user, accessToken, login, logout]


### PR DESCRIPTION
## 배경
- #25 
- AccessToekn 만료 시 쿠키 내의 RefreshToken으로 AccessToken 재발급

## 작업 사항
- **AccessToken 재발급 기능 구현** (7f0182ee1d68472c32831e92abf78f454241b58d)
  - `axios` 객체 내의 `interceptors`에서 Authorization 헤더를 관리하기 때문에 별도의 파일로 구현하지 않고 객체를 선언하는 파일 내에서 구현하였습니다.
  - 가독성을 위해 이전의 `token` -> `accessToken`으로 변경하였습니다.
- **에러 핸들링 추가** (56027e809ba8df59a14939fb0d77cefb4acea6fd)
  - 토큰 만료 시에만 재발급 실행
  - RefreshToken 미존재 시 로그아웃 처리
- **devleop 브랜치와 병합** (3b63496ec4dd2ba41ca03df36179afa82e5e1b43)
- **로그아웃 시 메인 화면으로 이동** (df1c40f94bedf6f4b7ccfadcd4eed0e076bf6d6b)
- **오타 수정** (dffb735a8bf19c4bafd268d4c97d04bbd6eb1d81)

## 추가 논의
- 로컬에서 테스트 완료했습니다.
