### PR TITLE
Fix: 배포 환경에서 로그아웃 오류

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,11 +9,19 @@ import GlobalStyles from "@/GlobalStyles";
 import KakaoRedirect from "@/components/sign-in/KakaoRedirect";
 import NaverRedirect from "@/components/sign-in/NaverRedirect";
 import SignUp from "@/pages/SignUp";
-import { AuthProvider } from "@/contexts/AuthProvider";
+import React from "react";
+import { useAuth } from "@/contexts/useAuth";
+import { setUpInterceptors } from "./api/authApi";
 
 const App = () => {
+  const { logout } = useAuth();
+
+  React.useEffect(() => {
+    setUpInterceptors(logout);
+  }, [logout]);
+
   return (
-    <AuthProvider>
+    <>
       <GlobalStyles />
       <Router>
         <Routes>
@@ -39,7 +47,7 @@ const App = () => {
           </Route>
         </Routes>
       </Router>
-    </AuthProvider>
+    </>
   );
 };
 

--- a/src/api/authApi.jsx
+++ b/src/api/authApi.jsx
@@ -1,13 +1,12 @@
 import axios from "axios";
 import { baseUrl } from "@/config/Env";
-import { useAuth } from "@/contexts/useAuth";
 
 const authApi = axios.create({
   baseURL: baseUrl,
   withCredentials: true,
 });
 
-export const reissueAccessToken = async (logout) => {
+const reissueAccessToken = async (logout) => {
   try {
     const response = await authApi.get("/auth/reissue");
     console.log(response);
@@ -39,40 +38,43 @@ export const reissueAccessToken = async (logout) => {
   }
 };
 
-authApi.interceptors.request.use(
-  (config) => {
-    const accessToken = localStorage.getItem("accessToken");
+export const setUpInterceptors = (logout) => {
+  authApi.interceptors.request.use(
+    (config) => {
+      const accessToken = localStorage.getItem("accessToken");
 
-    if (accessToken) {
-      config.headers.Authorization = `Bearer ${accessToken}`;
-    }
-    return config;
-  },
-  (error) => {
-    return Promise.reject(error);
-  }
-);
-
-authApi.interceptors.response.use(
-  (response) => response,
-  async (error) => {
-    const originalRequest = error.config;
-    const { logout } = useAuth();
-
-    if (error.response.data.code === "0004" && !originalRequest._retry) {
-      originalRequest._retry = true;
-      try {
-        const newAccessToken = await reissueAccessToken(logout);
-        authApi.defaults.headers["Authorization"] = `Bearer ${newAccessToken}`;
-        return authApi(originalRequest);
-      } catch (error) {
-        console.error("토큰 재발급 실패", error);
-        logout();
-        return Promise.reject(error);
+      if (accessToken) {
+        config.headers.Authorization = `Bearer ${accessToken}`;
       }
+      return config;
+    },
+    (error) => {
+      return Promise.reject(error);
     }
-    return Promise.reject(error);
-  }
-);
+  );
+
+  authApi.interceptors.response.use(
+    (response) => response,
+    async (error) => {
+      const originalRequest = error.config;
+
+      if (error.response.data.code === "0004" && !originalRequest._retry) {
+        originalRequest._retry = true;
+        try {
+          const newAccessToken = await reissueAccessToken(logout);
+          authApi.defaults.headers[
+            "Authorization"
+          ] = `Bearer ${newAccessToken}`;
+          return authApi(originalRequest);
+        } catch (error) {
+          console.error("토큰 재발급 실패", error);
+          logout();
+          return Promise.reject(error);
+        }
+      }
+      return Promise.reject(error);
+    }
+  );
+};
 
 export default authApi;

--- a/src/api/authApi.jsx
+++ b/src/api/authApi.jsx
@@ -13,7 +13,7 @@ const reissueAccessToken = async (logout) => {
 
     if (response.data.code === 200) {
       const { accessToken } = response.data.data;
-      localStorage.setItem("accessToken", accessToken);
+      sessionStorage.setItem("accessToken", accessToken);
       console.log("토큰 재발급 성공", accessToken);
       return accessToken;
     }
@@ -41,7 +41,7 @@ const reissueAccessToken = async (logout) => {
 export const setUpInterceptors = (logout) => {
   authApi.interceptors.request.use(
     (config) => {
-      const accessToken = localStorage.getItem("accessToken");
+      const accessToken = sessionStorage.getItem("accessToken");
 
       if (accessToken) {
         config.headers.Authorization = `Bearer ${accessToken}`;

--- a/src/contexts/AuthUtil.jsx
+++ b/src/contexts/AuthUtil.jsx
@@ -1,20 +1,20 @@
 export const getStoredUser = () => {
   try {
-    const storedUser = localStorage.getItem("user");
+    const storedUser = sessionStorage.getItem("user");
     return storedUser ? JSON.parse(storedUser) : null;
   } catch (error) {
-    console.error("로컬 스토리지에서 유저 데이터를 파싱하는 중 오류:", error);
-    localStorage.removeItem("user");
+    console.error("세션션 스토리지에서 유저 데이터를 파싱하는 중 오류:", error);
+    sessionStorage.removeItem("user");
     return null;
   }
 };
 
 export const getStoredToken = () => {
   try {
-    return localStorage.getItem("accessToken");
+    return sessionStorage.getItem("accessToken");
   } catch (error) {
-    console.error("로컬 스토리지에서 토큰을 읽는 중 오류:", error);
-    localStorage.removeItem("accessToken");
+    console.error("세션션 스토리지에서 토큰을 읽는 중 오류:", error);
+    sessionStorage.removeItem("accessToken");
     return null;
   }
 };
@@ -43,11 +43,11 @@ export const getNicknameFromToken = (token) => {
 };
 
 export const saveUserAndToken = (user, token) => {
-  localStorage.setItem("user", JSON.stringify(user));
-  localStorage.setItem("accessToken", token);
+  sessionStorage.setItem("user", JSON.stringify(user));
+  sessionStorage.setItem("accessToken", token);
 };
 
 export const clearStorage = () => {
-  localStorage.removeItem("user");
-  localStorage.removeItem("accessToken");
+  sessionStorage.removeItem("user");
+  sessionStorage.removeItem("accessToken");
 };

--- a/src/contexts/AuthUtil.jsx
+++ b/src/contexts/AuthUtil.jsx
@@ -13,7 +13,7 @@ export const getStoredToken = () => {
   try {
     return sessionStorage.getItem("accessToken");
   } catch (error) {
-    console.error("세션션 스토리지에서 토큰을 읽는 중 오류:", error);
+    console.error("세션 스토리지에서 토큰을 읽는 중 오류:", error);
     sessionStorage.removeItem("accessToken");
     return null;
   }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,4 +1,9 @@
 import { createRoot } from "react-dom/client";
 import App from "@/App.jsx";
+import { AuthProvider } from "@/contexts/AuthProvider";
 
-createRoot(document.getElementById("root")).render(<App />);
+createRoot(document.getElementById("root")).render(
+  <AuthProvider>
+    <App />
+  </AuthProvider>
+);


### PR DESCRIPTION
## 배경
- **배포 환경에서 로그아웃 시 invalid call 문제 발생**
  - `useAuth` 호출 위치 관련 문제로 추정
  - `useAUth` 의 호출은 리액트 컴포넌트 혹은 커스텀 훅 내에서만 이루어져야 함.

## 작업 사항
- **useAuth 호출 위치 변경** (c77daacf95071f3739bdd4c29e2a703d05dcf6d0)
  - 기존 코드에선 `interceptors` 안에서 호출
  - 리액트 컴포넌트인 `App`에서 `useAuth`를 호출
  - 리액트 앱 시작 시 `Interceptors`에 `useAuth`를 전달하도록 구현
- **AuthProvider 위치 변경** (3cb770f1f39f0b6098eef6e5851834984209b985)
  - `useAuth`는 `AuthProvider`로 감싸진 컴포넌트 내에서 호출되어야 함.
  - 기존 방식은 `App` 내에서 다른 컴포넌트들을 감싸는 구조
  - `main.jsx` 파일을 통해 `App` 자체를 감싸는 구조로 변경
- **로컬 스토리지 -> 세션 스토리지로 변경** (f9028c154ca64723bce9a528fb852e21c912852e)
  - 로컬 스토리지 방식에서는 API 권한 문제가 발생할 수 있음.
  - 브라우저를 끄면 초기화되는 세션 스토리지 방식을 통해 사용자의 재로그인 유도.
- **오타 수정** (dcaef5d8af307a995e733f4fbe529efb126d7d08)
- **세션 스토리지 추가 수정** (de36bcb112f050ce723ba71771017c3534b1ffa8)
    
## 추가 논의
- 로컬에서는 정상 작동되는데 배포 후에 다시 테스트해보겠습니다.