### PR TITLE
Feature: 메인 화면 내 뉴스 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { useEffect, useState } from "react";
 import { Route, BrowserRouter as Router, Routes } from "react-router-dom";
 import Layout from "@/components/layouts/Layout";
 import SignIn from "@/pages/SignIn";
@@ -15,10 +15,16 @@ import { setUpInterceptors } from "@/api/authApi";
 
 const App = () => {
   const { logout } = useAuth();
+  const [loading, setLoading] = useState(true);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setUpInterceptors(logout);
+    setLoading(false);
   }, [logout]);
+
+  if (loading) {
+    return null;
+  }
 
   return (
     <>

--- a/src/api/authApi.jsx
+++ b/src/api/authApi.jsx
@@ -6,7 +6,7 @@ const authApi = axios.create({
   withCredentials: true,
 });
 
-const reissueAccessToken = async (logout) => {
+export const reissueAccessToken = async (logout) => {
   try {
     const response = await authApi.get("/auth/reissue");
     if (response.data.code === 200) {

--- a/src/api/news/getNews.jsx
+++ b/src/api/news/getNews.jsx
@@ -1,0 +1,25 @@
+import authApi from "@/api/authApi";
+
+const getNews = async ({ page, size, sort }) => {
+  try {
+    const response = await authApi.get(
+      `news?page=${page}&size=${size}&sort=${sort}`
+    );
+
+    return response.data;
+  } catch (error) {
+    console.error("API 요청 중 오류 발생", error);
+    if (error.response) {
+      console.error("응답 오류:", error.response.data);
+      throw new Error("서버 오류 발생");
+    } else if (error.request) {
+      console.error("네트워크 오류 또는 서버 응답 없음");
+      throw new Error("네트워크 오류 또는 서버 응답 없음");
+    } else {
+      console.error("요청 설정 오류:", error.message);
+      throw new Error("요청 설정 오류");
+    }
+  }
+};
+
+export default getNews;

--- a/src/api/news/getNewsByKeyword.jsx
+++ b/src/api/news/getNewsByKeyword.jsx
@@ -1,0 +1,25 @@
+import authApi from "@/api/authApi";
+
+const getNewsByKeyword = async ({ page, size, sort, keyword }) => {
+  try {
+    const response = await authApi.get(
+      `news/search?page=${page}&size=${size}&sort=${sort}&keyword=${keyword}`
+    );
+
+    return response.data;
+  } catch (error) {
+    console.error("API 요청 중 오류 발생", error);
+    if (error.response) {
+      console.error("응답 오류:", error.response.data);
+      throw new Error("서버 오류 발생");
+    } else if (error.request) {
+      console.error("네트워크 오류 또는 서버 응답 없음");
+      throw new Error("네트워크 오류 또는 서버 응답 없음");
+    } else {
+      console.error("요청 설정 오류:", error.message);
+      throw new Error("요청 설정 오류");
+    }
+  }
+};
+
+export default getNewsByKeyword;

--- a/src/components/home/News.jsx
+++ b/src/components/home/News.jsx
@@ -1,5 +1,5 @@
 import getNews from "@/api/news/getNews";
-import getNewsByKeyword from "@/api/news/getNewsbyKeyword";
+import getNewsByKeyword from "@/api/news/getNewsByKeyword";
 import { useCallback, useEffect, useState } from "react";
 import styled, { css, keyframes } from "styled-components";
 

--- a/src/components/home/News.jsx
+++ b/src/components/home/News.jsx
@@ -1,0 +1,323 @@
+import getNews from "@/api/news/getNews";
+import getNewsByKeyword from "@/api/news/getNewsbyKeyword";
+import { useCallback, useEffect, useState } from "react";
+import styled, { css, keyframes } from "styled-components";
+
+const News = () => {
+  const [news, setNews] = useState([]);
+  const [page, setPage] = useState(0);
+  const [animatingOut, setAnimatingOut] = useState(false);
+  const [animatingIn, setAnimatingIn] = useState(false);
+  const [keyword, setKeyword] = useState("전체");
+
+  const keywords = ["전체", "코스닥", "코스피"];
+
+  const fetchNews = useCallback(async () => {
+    try {
+      const response = await getNews({
+        page: 0,
+        size: 50,
+        sort: "pubDate,desc",
+      });
+      setPage(0);
+      setNews(response.data.content);
+    } catch (error) {
+      console.error("주요 뉴스 가져오기 실패: ", error.message);
+    }
+  }, []);
+
+  const fetchNewsByKeyword = useCallback(async () => {
+    try {
+      const response = await getNewsByKeyword({
+        page: 0,
+        size: 50,
+        sort: "pubDate,desc",
+        keyword: keyword,
+      });
+      setPage(0);
+      setNews(response.data.content);
+    } catch (error) {
+      console.error("키워드 뉴스 가져오기 실패: ", error.message);
+    }
+  }, [keyword]);
+
+  useEffect(() => {
+    if (keyword === "전체") {
+      fetchNews();
+    } else {
+      fetchNewsByKeyword();
+    }
+  }, [fetchNews, fetchNewsByKeyword, keyword]);
+
+  const decodeHtmlEntities = (text) => {
+    const parser = new DOMParser();
+    const decodedString = parser.parseFromString(text, "text/html")
+      .documentElement.textContent;
+    return decodedString;
+  };
+
+  const getRelativeTime = (pubDate) => {
+    const now = new Date();
+    const publishedDate = new Date(pubDate);
+    const diffInSeconds = Math.floor((now - publishedDate) / 1000);
+
+    if (diffInSeconds < 60) {
+      return `${diffInSeconds}초 전`;
+    } else if (diffInSeconds < 3600) {
+      const minutes = Math.floor(diffInSeconds / 60);
+      return `${minutes}분 전`;
+    } else if (diffInSeconds < 86400) {
+      const hours = Math.floor(diffInSeconds / 3600);
+      return `${hours}시간 전`;
+    } else {
+      const days = Math.floor(diffInSeconds / 86400);
+      return `${days}일 전`;
+    }
+  };
+
+  const handleKeyword = (el) => () => {
+    setKeyword(el);
+  };
+
+  const handleNextPage = () => {
+    if (animatingOut || animatingIn) return;
+
+    setAnimatingOut(true);
+
+    setTimeout(() => {
+      setPage((prevPage) => (prevPage < 4 ? prevPage + 1 : 0));
+      setAnimatingOut(false);
+      setAnimatingIn(true);
+
+      setTimeout(() => {
+        setAnimatingIn(false);
+      }, 500);
+    }, 500);
+  };
+
+  return (
+    <NewsContainer>
+      <NewsHeader>
+        <NewsTitleContainer>
+          <NewsContainerTitle>주요 뉴스</NewsContainerTitle>
+          <NewsKeywords>
+            {keywords.map((el, index) => {
+              return (
+                <NewsKeyword
+                  key={index}
+                  $isActive={el === keyword}
+                  onClick={handleKeyword(el)}
+                >
+                  {el}
+                </NewsKeyword>
+              );
+            })}
+          </NewsKeywords>
+        </NewsTitleContainer>
+        <PageIndicators>
+          {Array.from({ length: 5 }).map((_, index) => (
+            <PageIndicator key={index} $isActive={index === page} />
+          ))}
+        </PageIndicators>
+      </NewsHeader>
+      <NewsContents>
+        <NewsTransitionContainer
+          $animatingOut={animatingOut}
+          $animatingIn={animatingIn}
+        >
+          <NewsColumn>
+            {news.slice(page * 10, page * 10 + 5).map((el, index) => {
+              return (
+                <NewsContent key={index} href={el.link}>
+                  <NewsTitle>{decodeHtmlEntities(el.title)}</NewsTitle>
+                  <NewsPubDate>{getRelativeTime(el.pubDate)}</NewsPubDate>
+                </NewsContent>
+              );
+            })}
+          </NewsColumn>
+          <NewsColumn>
+            {news.slice(page * 10 + 5, page * 10 + 10).map((el, index) => {
+              return (
+                <NewsContent key={index} href={el.link}>
+                  <NewsTitle>{decodeHtmlEntities(el.title)}</NewsTitle>
+                  <NewsPubDate>{getRelativeTime(el.pubDate)}</NewsPubDate>
+                </NewsContent>
+              );
+            })}
+          </NewsColumn>
+        </NewsTransitionContainer>
+        <MoreNewsBtn onClick={handleNextPage}>&gt;</MoreNewsBtn>
+      </NewsContents>
+    </NewsContainer>
+  );
+};
+
+export default News;
+
+const NewsContainer = styled.div`
+  min-height: 340px;
+  width: 100%;
+`;
+
+const NewsHeader = styled.header`
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 15px;
+  align-items: center;
+  width: 100%;
+`;
+
+const NewsTitleContainer = styled.div`
+  display: flex;
+  gap: 5px;
+  align-items: center;
+`;
+
+const NewsContainerTitle = styled.div`
+  font-weight: bold;
+  font-size: 20px;
+  color: #333d4b;
+  line-height: 1.45;
+`;
+
+const NewsKeywords = styled.div`
+  display: flex;
+  gap: 5px;
+  align-items: center;
+  margin-left: 10px;
+`;
+
+const NewsKeyword = styled.div`
+  background: #0220470d;
+  line-height: 1.45;
+  font-size: 15px;
+  text-decoration: none;
+  padding: 4px 12px;
+  cursor: pointer;
+  transition: 0.2s;
+  border-radius: 20px;
+  &:hover {
+    font-weight: 700;
+    color: #333d4b;
+  }
+  font-weight: ${({ $isActive }) => ($isActive ? 700 : 500)};
+  color: ${({ $isActive }) => ($isActive ? "#333d4b" : "#4e5968")};
+`;
+const PageIndicators = styled.div`
+  display: flex;
+  gap: 5px;
+  align-items: center;
+  padding-right: 35px;
+`;
+
+const PageIndicator = styled.div`
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background-color: ${({ $isActive }) => ($isActive ? "#333d4b" : "#ccc")};
+  transition: background-color 0.3s ease;
+`;
+
+const NewsContents = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+`;
+
+const slideOutLeft = keyframes`
+  from {
+    transform: translateX(0%);
+    opacity: 1;
+  }
+  to {
+    transform: translateX(-5%);
+    opacity: 0;
+  }
+`;
+
+const slideInRight = keyframes`
+  from {
+    transform: translateX(5%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0%);
+    opacity: 1;
+  }
+`;
+
+const NewsTransitionContainer = styled.div`
+  width: 100%;
+  display: grid;
+  grid-template-columns: minmax(10px, 1fr) minmax(10px, 1fr);
+  column-gap: 12px;
+  row-gap: 5px;
+  align-items: center;
+  overflow: hidden;
+  ${({ $animatingOut }) =>
+    $animatingOut &&
+    css`
+      animation: ${slideOutLeft} 0.5s ease-in-out;
+    `}
+
+  ${({ $animatingIn }) =>
+    $animatingIn &&
+    css`
+      animation: ${slideInRight} 0.5s ease-in-out;
+    `}
+`;
+
+const NewsColumn = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+`;
+
+const NewsContent = styled.a`
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  text-decoration: none;
+`;
+
+const NewsTitle = styled.span`
+  font-weight: 500;
+  color: #333d4b;
+  line-height: 1.45;
+  font-size: 15px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  word-break: break-all;
+  &:hover {
+    font-weight: 700;
+    color: #333d4b;
+  }
+`;
+
+const NewsPubDate = styled.span`
+  font-weight: 500;
+  color: #6b7684;
+  line-height: 1.45;
+  font-size: 14px;
+  padding-right: 28px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+`;
+
+const MoreNewsBtn = styled.a`
+  font-weight: 500;
+  color: #4e5968;
+  line-height: 1.45;
+  font-size: 25px;
+  text-decoration: none;
+  padding: 0 min(max(6px, 0.4em), 8px);
+  cursor: pointer;
+  transition: 0.2s;
+  border-radius: 6px;
+  &:hover {
+    font-weight: 700;
+    color: #333d4b;
+  }
+`;

--- a/src/components/layouts/Header.jsx
+++ b/src/components/layouts/Header.jsx
@@ -6,6 +6,7 @@ import useAuth from "@/contexts/useAuth";
 
 const Header = () => {
   const { user, logout } = useAuth();
+  const currentPath = window.location.pathname;
 
   const handleLogout = async () => {
     try {
@@ -34,10 +35,17 @@ const Header = () => {
         <NavCenter>
           <GNBControl>
             <GNBBtn>
-              <GNBAnchor href="/">홈</GNBAnchor>
+              <GNBAnchor href="/" $isActive={currentPath === "/"}>
+                홈
+              </GNBAnchor>
             </GNBBtn>
             <GNBBtn>
-              <GNBAnchor href="/">내 계좌</GNBAnchor>
+              <GNBAnchor
+                href="/account"
+                $isActive={currentPath.startsWith("/account")}
+              >
+                내 계좌
+              </GNBAnchor>
             </GNBBtn>
             <SearchBtn>
               <SearchIconBox role="presentation">
@@ -133,6 +141,8 @@ const GNBAnchor = styled.a`
     font-weight: 700;
     color: #333d4b;
   }
+  font-weight: ${({ $isActive }) => ($isActive ? 700 : 500)};
+  color: ${({ $isActive }) => ($isActive ? "#333d4b" : "#4e5968")};
 `;
 
 const SearchBtn = styled.button`
@@ -193,7 +203,7 @@ const LoginBtn = styled.a`
   width: auto;
   min-height: 32px;
   min-width: 16px;
-  margin: 0px 20px;
+  margin-left: 20px;
   font-weight: 600;
   white-space: nowrap;
   text-align: center;

--- a/src/components/layouts/Layout.jsx
+++ b/src/components/layouts/Layout.jsx
@@ -36,15 +36,15 @@ const ContentContainer = styled.div`
 
 const HeaderContainer = styled.header`
   position: fixed;
+  margin: auto;
   top: 0;
-  width: calc(100% - 65px);
+  width: calc(100% - 56px);
   min-width: 1000px;
   background: white;
   z-index: 1000;
 `;
 
 const MainContainer = styled.div`
-  padding: 0 40px;
   width: 100%;
   max-width: 1280px;
   margin: 60px auto 0 auto;

--- a/src/contexts/AuthProvider.jsx
+++ b/src/contexts/AuthProvider.jsx
@@ -38,7 +38,7 @@ const AuthProvider = ({ children }) => {
     setUser(null);
     setAccessToken(null);
     clearStorage();
-    window.location.herf = "/";
+    window.location.href = "/";
   }, []);
 
   const value = useMemo(

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,9 +1,18 @@
-import useAuth from "@/contexts/useAuth";
+import News from "@/components/home/News";
+import styled from "styled-components";
 
 const Home = () => {
-  const { user } = useAuth();
-
-  return <div>환영합니다, {user?.nickname}님</div>;
+  return (
+    <Container>
+      <News />
+    </Container>
+  );
 };
 
 export default Home;
+
+const Container = styled.section`
+  display: flex;
+  width: 100%;
+  margin-top: 56px;
+`;


### PR DESCRIPTION
## 배경
- 메인 화면 상에 주요 뉴스 구현

## 작업 사항
- **헤더 스타일 일부 변경** (8824793e6a630798cc1667ac4aef487702dc00d2)
- **인터셉터 호출 순서 변경** (d05c1571fc73dd46566c28ffbe06de0259812250)
  - 인터셉터가 API 보다 늦게 호출되어 Unauthorized 오류 발생
  - 로딩 플래그를 통해 호출 순서 변경
- **메인 화면 뉴스 구현** (2097b293b52176dfb4875d1a1b02327fd7d0b4cb)
- **오타 수정** (6d11a76502cd1b836b7a8fc2b391ae01a1233e9e, 9bd220074d42c1e76269c41e5271925ada460db1)

## 추가 논의
- 현재 썸네일이 별도로 없어서 추가적으로 뉴스 페이지를 만들기는 무리가 있다고 생각하여 넉넉하게 키워드 별로 50개를 메인 화면에 띄워주는 방식으로 구현했습니다.
- 기존에 논의했던 UI와 달라져 제가 임의로 구현했습니다. 추가적인 요구 사항 있으면 말씀해주세요.
![image](https://github.com/user-attachments/assets/e5704804-cf97-4936-b894-b8a56ac40b57)

