### PR TITLE
Refact: 애니메이션 지속 시간 변경

### DIFF
--- a/src/components/home/News.jsx
+++ b/src/components/home/News.jsx
@@ -257,7 +257,7 @@ const NewsTransitionContainer = styled.div`
   ${({ $animatingOut }) =>
     $animatingOut &&
     css`
-      animation: ${slideOutLeft} 0.5s ease-in-out;
+      animation: ${slideOutLeft} 0.6s ease-in-out;
     `}
 
   ${({ $animatingIn }) =>


### PR DESCRIPTION
## 배경
- **뉴스 화면 전환 시 가끔씩 버벅거리는 현상 발견**
  - 애니메이션이 전환되는 시간 사이에 재렌더링되는 것이 원인

## 작업 사항
- **애니메이션 지속 시간을 변경하여 해결** (c7263403d8b7f07320c139f0a87e408e6faf38ac)

## 추가 논의
- 진짜 숫자 하나만 바꿨습니다.
