### PR TITLE
Fix: 창 이동 시 모달창 종료

### DIFF
--- a/src/components/layouts/Header.jsx
+++ b/src/components/layouts/Header.jsx
@@ -73,6 +73,7 @@ const Header = () => {
   };
 
   const handleClickSearchedStock = (stock) => () => {
+    setIsModalOpen(false);
     navigate(`stocks/${stock.stockCode}`, { state: { stock } });
   };
 


### PR DESCRIPTION
## 배경
- 특정 종목 검색 후 해당 종목으로 창 이동 시에 모달창이 꺼지지 않는 현상 발견

## 작업 사항
- 특정 종목 화면으로 이동 시 모달창이 꺼지도록 수정 (3949c041312639c4388e3f14d44721b1fff069dd)
