### PR TITLE
Feature: 주식 종목 별 페이지 내 차트 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.7.9",
+        "lightweight-charts": "^5.0.1",
         "lodash": "^4.17.21",
         "prop-types": "^15.8.1",
         "react": "^18.3.1",
@@ -2610,6 +2611,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/fancy-canvas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fancy-canvas/-/fancy-canvas-2.1.0.tgz",
+      "integrity": "sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3475,6 +3481,14 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightweight-charts": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/lightweight-charts/-/lightweight-charts-5.0.1.tgz",
+      "integrity": "sha512-JjqI+Uoxuw/XESn6BeBp+o8kxa+CgvkbM7edhoarJ5KRjY1INqi0Hvahn88Q8Ou5sfckHbTGGKrM2lQQYsuH5A==",
+      "dependencies": {
+        "fancy-canvas": "2.1.0"
       }
     },
     "node_modules/lines-and-columns": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "axios": "^1.7.9",
+    "lightweight-charts": "^5.0.1",
     "lodash": "^4.17.21",
     "prop-types": "^15.8.1",
     "react": "^18.3.1",

--- a/src/api/stocks/getStockChart.jsx
+++ b/src/api/stocks/getStockChart.jsx
@@ -1,0 +1,23 @@
+import authApi from "@/api/authApi";
+
+const getStocksChart = async ({ stockCode, period }) => {
+  try {
+    const response = await authApi.get(`stocks/${stockCode}?period=${period}`);
+
+    return response.data;
+  } catch (error) {
+    console.error("API 요청 중 오류 발생", error);
+    if (error.response) {
+      console.error("응답 오류:", error.response.data);
+      throw new Error("서버 오류 발생");
+    } else if (error.request) {
+      console.error("네트워크 오류 또는 서버 응답 없음");
+      throw new Error("네트워크 오류 또는 서버 응답 없음");
+    } else {
+      console.error("요청 설정 오류:", error.message);
+      throw new Error("요청 설정 오류");
+    }
+  }
+};
+
+export default getStocksChart;

--- a/src/components/home/Rank.jsx
+++ b/src/components/home/Rank.jsx
@@ -1,8 +1,10 @@
 import getStocksRank from "@/api/stocks/getStocksRank";
 import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
 const Rank = () => {
+  const navigate = useNavigate();
   const [rank, setRank] = useState([]);
   const [type, setType] = useState("VOLUME");
   const [time, setTime] = useState("");
@@ -37,6 +39,11 @@ const Rank = () => {
 
   const handlePage = (pageNumber) => () => {
     setPage(pageNumber - 1);
+  };
+
+  const handleClickStock = (el) => () => {
+    const stock = { stockName: el.name, stockCode: el.code };
+    navigate(`stocks/${stock.stockCode}`, { state: { stock } });
   };
 
   return (
@@ -79,7 +86,11 @@ const Rank = () => {
               el.prdyCtrt < 0 ? Math.abs(el.prdyCtrt) : el.prdyCtrt;
             const formattedAvrgVol = el.avrgVol.toLocaleString();
             return (
-              <RankTableStock key={el.rank} $isOdd={el.rank % 2 !== 0}>
+              <RankTableStock
+                key={el.rank}
+                onClick={handleClickStock(el)}
+                $isOdd={el.rank % 2 !== 0}
+              >
                 <StockRanking>{el.rank}</StockRanking>
                 <StockName>{el.name}</StockName>
                 <StockPrice>{formattedPrice}원</StockPrice>

--- a/src/components/layouts/Layout.jsx
+++ b/src/components/layouts/Layout.jsx
@@ -1,13 +1,16 @@
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
 import Header from "@/components/layouts/Header";
 import styled from "styled-components";
 import SideBar from "@/components/layouts/SideBar";
 
 const Layout = () => {
+  const location = useLocation();
+  const isStockPage = location.pathname.startsWith("/stocks");
+
   return (
-    <Container>
+    <Container $isStockPage={isStockPage}>
       <ContentContainer>
-        <HeaderContainer>
+        <HeaderContainer $isStockPage={isStockPage}>
           <Header />
         </HeaderContainer>
         <MainContainer>
@@ -25,6 +28,7 @@ export default Layout;
 
 const Container = styled.div`
   display: flex;
+  background: ${({ $isStockPage }) => ($isStockPage ? "#F6F7F9" : "#fff")};
 `;
 
 const ContentContainer = styled.div`
@@ -42,6 +46,7 @@ const HeaderContainer = styled.header`
   min-width: 1000px;
   background: white;
   z-index: 1000;
+  background: ${({ $isStockPage }) => ($isStockPage ? "#F6F7F9" : "#fff")};
 `;
 
 const MainContainer = styled.div`

--- a/src/components/stocks/StockChart.jsx
+++ b/src/components/stocks/StockChart.jsx
@@ -1,0 +1,282 @@
+import { useEffect, useRef, useState } from "react";
+import PropTypes from "prop-types";
+import {
+  createChart,
+  CandlestickSeries,
+  HistogramSeries,
+} from "lightweight-charts";
+import styled from "styled-components";
+
+const StockChart = ({ chartData }) => {
+  const chartContainerRef = useRef(null);
+  const chartRef = useRef(null);
+  const [tooltipData, setTooltipData] = useState(null);
+  const tooltipCategory = [
+    {
+      title: "시가",
+      value: "open",
+      price: tooltipData?.open,
+      change: tooltipData?.openChange,
+    },
+    {
+      title: "고가",
+      value: "high",
+      price: tooltipData?.high,
+      change: tooltipData?.highChange,
+    },
+    {
+      title: "저가",
+      value: "low",
+      price: tooltipData?.low,
+      change: tooltipData?.lowChange,
+    },
+    {
+      title: "종가",
+      value: "close",
+      price: tooltipData?.close,
+      change: tooltipData?.closeChange,
+    },
+    {
+      title: "거래량",
+      value: "volume",
+      price: tooltipData?.volume,
+      change: tooltipData?.volumeChange,
+    },
+  ];
+
+  useEffect(() => {
+    if (!chartContainerRef.current || !chartData || chartData.length === 0)
+      return;
+
+    const chart = createChart(chartContainerRef.current, {
+      width: chartContainerRef.current.clientWidth,
+      height: 500,
+      layout: {
+        backgroundColor: "#ffffff",
+        textColor: "#000000",
+      },
+      grid: {
+        vertLines: { color: "#e1e1e1" },
+        horzLines: { color: "#e1e1e1" },
+      },
+      timeScale: {
+        visible: true,
+      },
+      rightPriceScale: {
+        visible: true,
+        borderVisible: false,
+      },
+    });
+
+    chartRef.current = chart;
+
+    const candleSeries = chart.addSeries(CandlestickSeries, {
+      upColor: "#f04452",
+      downColor: "#3182f6",
+      borderUpColor: "#f04452",
+      borderDownColor: "#3182f6",
+      wickUpColor: "#f04452",
+      wickDownColor: "#3182f6",
+      priceFormat: {
+        type: "custom",
+        minMove: 1,
+        formatter: (price) => price.toLocaleString("en-US"),
+      },
+      priceScaleId: "right",
+    });
+
+    const volumeSeries = chart.addSeries(HistogramSeries, {
+      color: "#26a69a",
+      priceFormat: { type: "volume" },
+      priceScaleId: "volume",
+    });
+
+    candleSeries.setData(
+      chartData.map((el) => ({
+        time: el.time,
+        open: el.open,
+        high: el.high,
+        low: el.low,
+        close: el.close,
+      }))
+    );
+    volumeSeries.setData(
+      chartData.map((el) => ({
+        time: el.time,
+        value: el.value,
+        color: el.open < el.close ? "#f04452" : "#3182f6",
+      }))
+    );
+
+    chart.priceScale("right").applyOptions({
+      scaleMargins: { top: 0.1, bottom: 0.3 },
+    });
+    chart.priceScale("volume").applyOptions({
+      scaleMargins: { top: 0.8, bottom: 0 },
+    });
+
+    const handleResize = () => {
+      chart.resize(chartContainerRef.current.clientWidth, 600);
+    };
+    window.addEventListener("resize", handleResize);
+
+    const totalDataPoints = chartData.length;
+    if (totalDataPoints > 75) {
+      chart.timeScale().setVisibleRange({
+        from: chartData[totalDataPoints - 75].time,
+        to: chartData[totalDataPoints - 1].time,
+      });
+    }
+
+    const minLogicalIndex = 0;
+    const maxLogicalIndex = chartData.length - 1;
+
+    const restrictNavigation = () => {
+      const timeScale = chart.timeScale();
+      const logicalRange = timeScale.getVisibleLogicalRange();
+
+      if (logicalRange) {
+        const adjustedRange = {
+          from: Math.max(logicalRange.from, minLogicalIndex),
+          to: Math.min(logicalRange.to, maxLogicalIndex),
+        };
+
+        if (
+          logicalRange.from < minLogicalIndex ||
+          logicalRange.to > maxLogicalIndex
+        ) {
+          timeScale.setVisibleLogicalRange(adjustedRange);
+        }
+      }
+    };
+
+    chart.timeScale().subscribeVisibleLogicalRangeChange(restrictNavigation);
+
+    chart.subscribeCrosshairMove((param) => {
+      if (!param.time || !param.seriesData) {
+        setTooltipData(null);
+        return;
+      }
+
+      const candleData = param.seriesData.get(candleSeries);
+      const volumeData = param.seriesData.get(volumeSeries);
+      if (!candleData || !volumeData) {
+        setTooltipData(null);
+        return;
+      }
+      const { open, high, low, close } = candleData;
+      const volume = volumeData.value;
+
+      const currentIndex = chartData.findIndex((el) => el.time === param.time);
+      const prevData = currentIndex > 0 ? chartData[currentIndex - 1] : null;
+
+      const calculateChange = (current, previous) => {
+        return previous !== null
+          ? (((current - previous) / previous) * 100).toFixed(2)
+          : null;
+      };
+
+      setTooltipData({
+        time: param.time,
+        open,
+        high,
+        low,
+        close,
+        volume,
+        openChange: prevData ? calculateChange(open, prevData.open) : null,
+        highChange: prevData ? calculateChange(high, prevData.high) : null,
+        lowChange: prevData ? calculateChange(low, prevData.low) : null,
+        closeChange: prevData ? calculateChange(close, prevData.close) : null,
+        volumeChange: prevData ? calculateChange(volume, prevData.value) : null,
+      });
+    });
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      chart.remove();
+    };
+  }, [chartData]);
+
+  return (
+    <ChartContainer>
+      <Chart ref={chartContainerRef} />
+      {tooltipData && (
+        <TooltipContainer>
+          <TooltipPrice>
+            <strong>{tooltipData.time}</strong>
+          </TooltipPrice>
+          {tooltipCategory.map((el, index) => {
+            return (
+              <TooltipInfo key={index}>
+                <TooltipTitle>{el.title}:</TooltipTitle>
+                <TooltipPrice>{el.price.toLocaleString()}</TooltipPrice>
+                <TooltipChange $change={el.change}>
+                  {el.change !== null
+                    ? `(${el.change > 0 ? "+" : ""}${el.change}%)`
+                    : ""}
+                </TooltipChange>
+              </TooltipInfo>
+            );
+          })}
+        </TooltipContainer>
+      )}
+    </ChartContainer>
+  );
+};
+
+StockChart.propTypes = {
+  chartData: PropTypes.arrayOf(
+    PropTypes.shape({
+      time: PropTypes.string.isRequired,
+      open: PropTypes.number.isRequired,
+      high: PropTypes.number.isRequired,
+      low: PropTypes.number.isRequired,
+      close: PropTypes.number.isRequired,
+      value: PropTypes.number.isRequired,
+    })
+  ).isRequired,
+};
+
+export default StockChart;
+
+const ChartContainer = styled.div`
+  position: relative;
+`;
+
+const Chart = styled.div`
+  height: 500px;
+  width: 100%;
+`;
+
+const TooltipContainer = styled.div`
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  background-color: white;
+  border-radius: 4px;
+  padding: 8px;
+  font-size: 12px;
+  z-index: 1000;
+  pointer-events: none;
+  display: flex;
+  gap: 6px;
+`;
+
+const TooltipInfo = styled.div`
+  display: flex;
+  gap: 2px;
+`;
+
+const TooltipTitle = styled.span`
+  font-weight: 500;
+  color: #000;
+`;
+
+const TooltipPrice = styled.span`
+  color: #4e5968;
+`;
+
+const TooltipChange = styled.span`
+  color: ${({ $change }) =>
+    $change > 0 ? "#f04452" : $change < 0 ? "#3182f6" : "#4e5968"};
+`;

--- a/src/components/stocks/StockChartContainer.jsx
+++ b/src/components/stocks/StockChartContainer.jsx
@@ -1,0 +1,140 @@
+import { useState, useEffect } from "react";
+import StockChart from "./StockChart";
+import getStocksChart from "@/api/stocks/getStockChart";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+
+const StockChartContainer = ({ stock }) => {
+  const [chartData, setChartData] = useState([]);
+  const [period, setPeriod] = useState("DAILY");
+
+  const periods = [
+    { value: "DAILY", korean: "일" },
+    { value: "WEEKLY", korean: "주" },
+    { value: "MONTHLY", korean: "월" },
+    { value: "YEARLY", korean: "년" },
+  ];
+
+  useEffect(() => {
+    const fetchChartData = async () => {
+      try {
+        const response = await getStocksChart({
+          stockCode: stock.stockCode,
+          period: period,
+        });
+        const transformedChartData = response.data.map((el) => ({
+          time: el.date,
+          open: el.open,
+          high: el.high,
+          low: el.low,
+          close: el.close,
+          value: el.volume,
+        }));
+        setChartData(transformedChartData);
+      } catch (error) {
+        console.error("주식 차트 데이터 가져오기 실패:", error.message);
+      }
+    };
+
+    fetchChartData();
+  }, [stock.stockCode, period]);
+
+  const handlePeriod = (period) => () => {
+    setPeriod(period);
+  };
+
+  return (
+    <StockContainer>
+      <StockName>{stock.stockName}</StockName>
+      <ChartContainer>
+        <ChartHeader>
+          <ChartTitle>차트</ChartTitle>
+          <ChartPeriods>
+            {periods.map((el, index) => {
+              return (
+                <ChartPeriod
+                  key={index}
+                  onClick={handlePeriod(el.value)}
+                  $isActive={period === el.value}
+                >
+                  {el.korean}
+                </ChartPeriod>
+              );
+            })}
+          </ChartPeriods>
+        </ChartHeader>
+        <StockChart chartData={chartData} />
+      </ChartContainer>
+    </StockContainer>
+  );
+};
+
+StockChartContainer.propTypes = {
+  stock: PropTypes.shape({
+    stockName: PropTypes.string.isRequired,
+    stockCode: PropTypes.string.isRequired,
+  }),
+};
+
+export default StockChartContainer;
+
+const StockContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const StockName = styled.div`
+  font-size: 25px;
+  font-weight: bold;
+  color: #333d4b;
+  line-height: 1.3;
+  padding: 8px;
+`;
+
+const ChartContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 8px 16px;
+  border-radius: 16px;
+  background: #fff;
+`;
+
+const ChartHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  font-size: 14px;
+  align-items: center;
+  padding: 8px 0px;
+  margin-bottom: 16px;
+  margin-right: 22px;
+`;
+
+const ChartTitle = styled.div`
+  font-weight: bold;
+  color: #333d4b;
+  line-height: 1.45;
+`;
+
+const ChartPeriods = styled.div`
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+`;
+
+const ChartPeriod = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-weight: 600;
+  font-size: 14px;
+  color: #031228b2;
+  min-height: 32px;
+  min-width: 16px;
+  padding: 4px 12px;
+  border-radius: 8px;
+  background: ${({ $isActive }) => ($isActive ? "#0220470d" : " #fff")};
+  cursor: pointer;
+  &:hover {
+    background: #0220470d;
+  }
+`;

--- a/src/pages/Stocks.jsx
+++ b/src/pages/Stocks.jsx
@@ -1,9 +1,10 @@
+import StockChartContainer from "@/components/stocks/StockChartContainer";
 import { useLocation } from "react-router-dom";
 
 const Stocks = () => {
   const location = useLocation();
   const stock = location.state?.stock;
-  return <div>{stock.stockName}종목 화면입니다.</div>;
+  return <StockChartContainer stock={stock} />;
 };
 
 export default Stocks;


### PR DESCRIPTION
## 배경
- #38 
- 주식 종목 별 차트 구현

## 작업 사항
- **lightweight-charts 라이브러리 다운** (559078859159734e1462849ebef70f43c96ab5b9)
  - `TradingView`에서 제공하는 `lightweight-charts` 라이브러리를 사용하였습니다.
- **차트 데이터 API 구현** (5c281b2819efbd4b57543504962b50c2249b19a8)
- **차트 구현** (1766d002a0dcc7565cf6b2a8919ddc8998253ffd)
  - 가격, 거래량을 하나의 차트로 구현
  - 초기 진입 시 75개의 데이터 렌더링
  - 확대, 축소, 드래그
  - Tooltip 기능 지원 (호버 시 좌상단에 해당 날짜 정보 표시)
- **종목 페이지 배경 색 변경** (9e21e29abd7705cef051cfe4e4559c1882f6ba2d)
- **랭킹 내 주식 클릭 시 종목 차트로 이동** (296c47f44ade9e9a67b73724998100036b7cd42d)
![image](https://github.com/user-attachments/assets/808a8d8b-129d-4010-80eb-1b7f5226e7d0)



## 추가 논의
-  차트의 Y축은 가격의 정보만 뜹니다. 아래쪽은 거래량의 Y축으로 구성하려 했지만 지원하지 않는 기능이라서 실패했습니다. 호버 시에 Tooltip을 통해 거래량 정보를 제공합니다!
- 랭킹 주식에서 테스트를 하던 도중 알게 된 사실인데 `KODEX 200 선물인버스 2X`, `삼성 인버스 2X WTI원유 선물 ETN` 등의 종목들은 검색에도 뜨지 않고 차트데이터 호출도 되지 않는 것을 확인했습니다. 정식 종목이 아니라서 그런건가요?