### PR TITLE
Feature: 현재 계좌 정보 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import GlobalStyles from "@/GlobalStyles";
 import KakaoRedirect from "@/components/auth/KakaoRedirect";
 import NaverRedirect from "@/components/auth/NaverRedirect";
 import SignUp from "@/pages/SignUp";
+import AccountLayout from "@/components/layouts/AccountLayout";
 import useAuth from "@/contexts/useAuth";
 import { setUpInterceptors } from "@/api/authApi";
 
@@ -44,9 +45,7 @@ const App = () => {
             <Route path="stocks/:stockcode" element={<Stocks />} />
 
             {/* 내 계좌 경로 */}
-            <Route path="account">
-              {/* 기본 경로 or asset */}
-              <Route index element={<Asset />} />
+            <Route path="account" element={<AccountLayout />}>
               <Route path="asset" element={<Asset />} />
               <Route path="transactions" element={<Transactions />} />
             </Route>

--- a/src/api/account/getCurrentAccount.jsx
+++ b/src/api/account/getCurrentAccount.jsx
@@ -1,0 +1,22 @@
+import authApi from "@/api/authApi";
+
+const getCurrentAccount = async () => {
+  try {
+    const response = await authApi.get(`accounts/current`);
+    return response.data;
+  } catch (error) {
+    console.error("API 요청 중 오류 발생", error);
+    if (error.response) {
+      console.error("응답 오류:", error.response.data);
+      throw new Error("서버 오류 발생");
+    } else if (error.request) {
+      console.error("네트워크 오류 또는 서버 응답 없음");
+      throw new Error("네트워크 오류 또는 서버 응답 없음");
+    } else {
+      console.error("요청 설정 오류:", error.message);
+      throw new Error("요청 설정 오류");
+    }
+  }
+};
+
+export default getCurrentAccount;

--- a/src/components/account/AccountNavBar.jsx
+++ b/src/components/account/AccountNavBar.jsx
@@ -1,0 +1,69 @@
+import { useLocation } from "react-router-dom";
+import styled from "styled-components";
+
+const AccountNavBar = () => {
+  const location = useLocation();
+
+  const accountNavBtns = [
+    { value: "asset", korean: "자산" },
+    { value: "transactions", korean: "거래 내역" },
+  ];
+
+  return (
+    <AccountNav>
+      <AccountNavBtns>
+        {accountNavBtns.map((el, index) => {
+          return (
+            <AccountNavBtn key={index}>
+              <AccountNavAnchor
+                href={el.value}
+                $isActive={location.pathname.includes(el.value)}
+              >
+                {el.korean}
+              </AccountNavAnchor>
+            </AccountNavBtn>
+          );
+        })}
+      </AccountNavBtns>
+    </AccountNav>
+  );
+};
+
+export default AccountNavBar;
+
+const AccountNav = styled.nav`
+  display: flex;
+  flex-direction: column;
+  position: sticky;
+  top: 60px;
+  width: 184px;
+`;
+
+const AccountNavBtns = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+`;
+
+const AccountNavBtn = styled.li`
+  list-style: none;
+  display: flex;
+  align-items: center;
+`;
+
+const AccountNavAnchor = styled.a`
+  text-decoration: none;
+  padding: 8px 14px;
+  width: 100%;
+  border-radius: 8px;
+  font-size: 15px;
+  line-height: 1.45;
+  transition: 0.3s;
+  cursor: pointer;
+  font-weight: ${({ $isActive }) => ($isActive ? "bold" : 500)};
+  color: ${({ $isActive }) => ($isActive ? "#000c1ecc" : "#031228b2")};
+  background: ${({ $isActive }) => ($isActive ? "#0220470D" : "#fff")};
+  &:hover {
+    background: #0220470d;
+  }
+`;

--- a/src/components/account/CurrentAccount.jsx
+++ b/src/components/account/CurrentAccount.jsx
@@ -1,0 +1,96 @@
+import getCurrentAccount from "@/api/account/getCurrentAccount";
+import { useEffect, useState } from "react";
+import styled from "styled-components";
+
+const CurrentAccount = () => {
+  const [currentAccount, setCurrentAccount] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const totalAsset = currentAccount.balance + currentAccount.reservedPrice;
+
+  const fetchCurrentAccount = async () => {
+    try {
+      const response = await getCurrentAccount();
+      console.log(response);
+      setCurrentAccount(response.data);
+      setIsLoading(false);
+    } catch (error) {
+      console.error("현재 계좌 가져오기 실패 : ", error.message);
+    }
+  };
+
+  useEffect(() => {
+    fetchCurrentAccount();
+  }, []);
+
+  if (isLoading) return null;
+
+  return (
+    <CurrentAccountContainer>
+      <BalanceContainer>
+        <Title>현재 내 자산</Title>
+        <Balance>{totalAsset.toLocaleString()} 원</Balance>
+      </BalanceContainer>
+      <AssetsContainer>
+        <AssetContainer>
+          <Title>주문 가능 금액</Title>
+          <AvailableBalance>
+            {currentAccount.balance.toLocaleString()} 원
+          </AvailableBalance>
+        </AssetContainer>
+        <AssetContainer>
+          <Title>투자 중인 금액</Title>
+          <AvailableBalance>- 원</AvailableBalance>
+        </AssetContainer>
+      </AssetsContainer>
+    </CurrentAccountContainer>
+  );
+};
+
+export default CurrentAccount;
+
+const CurrentAccountContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+`;
+
+const BalanceContainer = styled.div``;
+
+const Title = styled.div`
+  font-weight: normal;
+  font-size: 15px;
+  color: #4e5968;
+  line-height: 1.45;
+`;
+
+const Balance = styled.div`
+  font-weight: 600;
+  color: #333d4b;
+  line-height: 1.45;
+  font-size: 24px;
+`;
+
+const AssetsContainer = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+`;
+
+const AssetContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  min-width: 270px;
+  height: 100%;
+  padding: 20px 24px;
+  background: #f9fafb;
+  border-radius: 15px;
+  gap: 12px;
+`;
+
+const AvailableBalance = styled.div`
+  font-weight: 600;
+  color: #333d4b;
+  line-height: 1.45;
+  font-size: 20px;
+`;

--- a/src/components/layouts/AccountLayout.jsx
+++ b/src/components/layouts/AccountLayout.jsx
@@ -1,0 +1,21 @@
+import { Outlet } from "react-router-dom";
+import AccountNavBar from "../account/AccountNavBar";
+import styled from "styled-components";
+
+const AccountLayout = () => {
+  return (
+    <Container>
+      <AccountNavBar />
+      <Outlet />
+    </Container>
+  );
+};
+
+export default AccountLayout;
+
+const Container = styled.div`
+  display: grid;
+  grid-template-columns: 184px minmax(10px, 1fr);
+  column-gap: 40px;
+  margin-top: 48px;
+`;

--- a/src/components/layouts/Header.jsx
+++ b/src/components/layouts/Header.jsx
@@ -103,7 +103,7 @@ const Header = () => {
             </GNBBtn>
             <GNBBtn>
               <GNBAnchor
-                href="/account"
+                href="/account/asset"
                 $isActive={currentPath.startsWith("/account")}
               >
                 내 계좌

--- a/src/pages/Asset.jsx
+++ b/src/pages/Asset.jsx
@@ -1,5 +1,17 @@
+import CurrentAccount from "@/components/account/CurrentAccount";
+import styled from "styled-components";
+
 const Asset = () => {
-  return <div>자산 페이지입니다.</div>;
+  return (
+    <AssetContainer>
+      <CurrentAccount />
+    </AssetContainer>
+  );
 };
 
 export default Asset;
+
+const AssetContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;


### PR DESCRIPTION
## 배경
- #40 
- 자산 페이지 내에 현재 나의 계좌 정보를 보여줌

## 작업 사항
- **자산 페이지 URL 변경** (275d8d6ccc6ab46868886d4d02e295f2bd483a15)
  - `/account` -> `/account/asset`
- **계좌 레이아웃 구현** (aab3e53b4900b8642f074327cae39bce8aad226a)
  - `/account`로 시작하는 페이지에 한해 레이아웃 추가
- **최근 계좌 정보 불러오기 API 연결** (df8764064d789e5d535ff6f148a3d74de6c2cc00)
- **자산 페이지 내 현재 계좌 정보 구현** (1fe527c855ac174d3708f5be24eaea3e8dc27cf2)

## 추가 논의
- 현재는 간단한 정보들만 제작해두었습니다. 투자 중인 금액은 임의로 `- 원`으로 표기해뒀습니다.
![image](https://github.com/user-attachments/assets/684d8381-0d95-426e-9a5c-821fe344366c)

- **계좌 차트 제작**
  - 계좌 생성된 이후로 일(주, 월)별 데이터 저장이 가능한가요? 가능하다면 토스증권 아래와 같은 자산 화면 차트 제작이 가능합니다.
    ![image](https://github.com/user-attachments/assets/2d6ceb5c-3f5f-445b-acc2-b818a0ab0535)
- **추후 작업 사항**
  - 토큰 재발급 관련 이슈가 존재해서 그 부분부터 먼저 해결할 예정입니다.
