### PR TITLE
Fix: 토큰 재발급 무한 요청

### DIFF
--- a/src/api/auth/socialSignIn.jsx
+++ b/src/api/auth/socialSignIn.jsx
@@ -1,8 +1,8 @@
-import noAuthapi from "@/api/noAuthApi";
+import noAuthApi from "@/api/noAuthApi";
 
 const socialSignIn = async (platform, code) => {
   try {
-    const response = await noAuthapi.post(`auth/sign-in/${platform}`, { code });
+    const response = await noAuthApi.post(`auth/sign-in/${platform}`, { code });
     return response.data;
   } catch (error) {
     console.error("API 요청 중 오류 발생", error);

--- a/src/api/authApi.jsx
+++ b/src/api/authApi.jsx
@@ -54,7 +54,6 @@ export const setUpInterceptors = (logout) => {
       const originalRequest = error.config;
       if (error.response.data.code === "0004" && !originalRequest._retry) {
         originalRequest._retry = true;
-        console.log("오류 발생!!!!");
         try {
           const newAccessToken = await reissueAccessToken(logout);
           authApi.defaults.headers[

--- a/src/api/authApi.jsx
+++ b/src/api/authApi.jsx
@@ -1,14 +1,15 @@
 import axios from "axios";
 import { baseUrl } from "@/config/Env";
+import noAuthapi from "./noAuthApi";
 
 const authApi = axios.create({
   baseURL: baseUrl,
   withCredentials: true,
 });
 
-export const reissueAccessToken = async (logout) => {
+const reissueAccessToken = async (logout) => {
   try {
-    const response = await authApi.get("/auth/reissue");
+    const response = await noAuthapi.get("/auth/reissue");
     if (response.data.code === 200) {
       const { accessToken } = response.data.data;
       sessionStorage.setItem("accessToken", accessToken);
@@ -53,6 +54,7 @@ export const setUpInterceptors = (logout) => {
       const originalRequest = error.config;
       if (error.response.data.code === "0004" && !originalRequest._retry) {
         originalRequest._retry = true;
+        console.log("오류 발생!!!!");
         try {
           const newAccessToken = await reissueAccessToken(logout);
           authApi.defaults.headers[

--- a/src/api/noAuthApi.jsx
+++ b/src/api/noAuthApi.jsx
@@ -1,9 +1,9 @@
 import axios from "axios";
 import { baseUrl } from "@/config/Env";
 
-const noAuthapi = axios.create({
+const noAuthApi = axios.create({
   baseURL: baseUrl,
   withCredentials: true,
 });
 
-export default noAuthapi;
+export default noAuthApi;


### PR DESCRIPTION
## 배경
- **토큰 만료 시 재발급을 무한으로 요청하는 현상 발생**
  - 재발급한 토큰으로 헤더를 변경하기 전에 다시 에러 처리를 시작해서 발생
  - 재발급 API 객체를 헤더에 AccessToken이 없는 `noAuthApi` 객체로 요청

## 작업 사항
- **토큰 재발급 API 객체 변경** (597cb0fee109f5d9adffefdd256cf258665baa2e)
- **변수명 수정** (e3b4939d8ff92df50eaa1fb66dd18af6be9a8186)
- **`console.log()` 삭제** (388686030c374f875342242916a71ed39a2d1ea4)
