### PR TITLE
Feature: 주식 매수 및 매도 UI 구성

### DIFF
--- a/src/components/layouts/Layout.jsx
+++ b/src/components/layouts/Layout.jsx
@@ -1,16 +1,13 @@
-import { Outlet, useLocation } from "react-router-dom";
+import { Outlet } from "react-router-dom";
 import Header from "@/components/layouts/Header";
 import styled from "styled-components";
 import SideBar from "@/components/layouts/SideBar";
 
 const Layout = () => {
-  const location = useLocation();
-  const isStockPage = location.pathname.startsWith("/stocks");
-
   return (
-    <Container $isStockPage={isStockPage}>
+    <Container>
       <ContentContainer>
-        <HeaderContainer $isStockPage={isStockPage}>
+        <HeaderContainer>
           <Header />
         </HeaderContainer>
         <MainContainer>
@@ -28,7 +25,6 @@ export default Layout;
 
 const Container = styled.div`
   display: flex;
-  background: ${({ $isStockPage }) => ($isStockPage ? "#F6F7F9" : "#fff")};
 `;
 
 const ContentContainer = styled.div`
@@ -46,7 +42,6 @@ const HeaderContainer = styled.header`
   min-width: 1000px;
   background: white;
   z-index: 1000;
-  background: ${({ $isStockPage }) => ($isStockPage ? "#F6F7F9" : "#fff")};
 `;
 
 const MainContainer = styled.div`

--- a/src/components/stocks/StockChart.jsx
+++ b/src/components/stocks/StockChart.jsx
@@ -50,7 +50,7 @@ const StockChart = ({ chartData }) => {
 
     const chart = createChart(chartContainerRef.current, {
       width: chartContainerRef.current.clientWidth,
-      height: 500,
+      height: chartContainerRef.current.clientHeight,
       layout: {
         backgroundColor: "#ffffff",
         textColor: "#000000",
@@ -61,6 +61,7 @@ const StockChart = ({ chartData }) => {
       },
       timeScale: {
         visible: true,
+        borderVisible: false,
       },
       rightPriceScale: {
         visible: true,
@@ -116,7 +117,10 @@ const StockChart = ({ chartData }) => {
     });
 
     const handleResize = () => {
-      chart.resize(chartContainerRef.current.clientWidth, 600);
+      chart.resize(
+        chartContainerRef.current.clientWidth,
+        chartContainerRef.current.clientHeight
+      );
     };
     window.addEventListener("resize", handleResize);
 
@@ -197,6 +201,10 @@ const StockChart = ({ chartData }) => {
     };
   }, [chartData]);
 
+  if (chartData.length === 0) {
+    return <LoadingChart>지원하지 않는 차트입니다.</LoadingChart>;
+  }
+
   return (
     <ChartContainer>
       <Chart ref={chartContainerRef} />
@@ -241,6 +249,7 @@ export default StockChart;
 
 const ChartContainer = styled.div`
   position: relative;
+  height: 500px;
 `;
 
 const Chart = styled.div`
@@ -250,11 +259,7 @@ const Chart = styled.div`
 
 const TooltipContainer = styled.div`
   position: absolute;
-  top: 10px;
-  left: 10px;
-  background-color: white;
-  border-radius: 4px;
-  padding: 8px;
+  top: -30px;
   font-size: 12px;
   z-index: 1000;
   pointer-events: none;
@@ -279,4 +284,13 @@ const TooltipPrice = styled.span`
 const TooltipChange = styled.span`
   color: ${({ $change }) =>
     $change > 0 ? "#f04452" : $change < 0 ? "#3182f6" : "#4e5968"};
+`;
+
+const LoadingChart = styled.div`
+  height: 500px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-weight: bold;
+  color: #333d4b;
 `;

--- a/src/components/stocks/StockChartContainer.jsx
+++ b/src/components/stocks/StockChartContainer.jsx
@@ -45,10 +45,8 @@ const StockChartContainer = ({ stock }) => {
 
   return (
     <StockContainer>
-      <StockName>{stock.stockName}</StockName>
       <ChartContainer>
         <ChartHeader>
-          <ChartTitle>차트</ChartTitle>
           <ChartPeriods>
             {periods.map((el, index) => {
               return (
@@ -81,38 +79,21 @@ export default StockChartContainer;
 const StockContainer = styled.div`
   display: flex;
   flex-direction: column;
-`;
-
-const StockName = styled.div`
-  font-size: 25px;
-  font-weight: bold;
-  color: #333d4b;
-  line-height: 1.3;
-  padding: 8px;
+  width: 70%;
 `;
 
 const ChartContainer = styled.div`
   display: flex;
   flex-direction: column;
-  padding: 8px 16px;
-  border-radius: 16px;
-  background: #fff;
 `;
 
 const ChartHeader = styled.div`
   display: flex;
-  justify-content: space-between;
+  justify-content: end;
   font-size: 14px;
   align-items: center;
-  padding: 8px 0px;
   margin-bottom: 16px;
   margin-right: 22px;
-`;
-
-const ChartTitle = styled.div`
-  font-weight: bold;
-  color: #333d4b;
-  line-height: 1.45;
 `;
 
 const ChartPeriods = styled.div`

--- a/src/components/stocks/StockHeader.jsx
+++ b/src/components/stocks/StockHeader.jsx
@@ -1,0 +1,77 @@
+import PropTypes from "prop-types";
+import styled from "styled-components";
+
+const StockHeader = ({ stock }) => {
+  return (
+    <StockHeaderContainer>
+      <StockInfo>
+        <StockName>{stock.stockName}</StockName>
+        <StockCode>{stock.stockCode}</StockCode>
+      </StockInfo>
+      <StockPrice>
+        <CurrentPrice>000원</CurrentPrice>
+        <PriceText>어제보다</PriceText>
+        <PriceChange>0원 (0.0)%</PriceChange>
+      </StockPrice>
+    </StockHeaderContainer>
+  );
+};
+
+StockHeader.propTypes = {
+  stock: PropTypes.shape({
+    stockName: PropTypes.string.isRequired,
+    stockCode: PropTypes.string.isRequired,
+  }),
+};
+
+export default StockHeader;
+
+const StockHeaderContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+`;
+
+const StockInfo = styled.div`
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  font-size: 20px;
+  line-height: 1.5;
+`;
+
+const StockName = styled.span`
+  font-weight: 600;
+  color: #333d4b;
+`;
+
+const StockCode = styled.span`
+  font-weight: 500;
+  color: #8b95a1;
+`;
+
+const StockPrice = styled.div`
+  display: flex;
+  align-items: center;
+  line-height: 1.45;
+`;
+
+const CurrentPrice = styled.span`
+  font-weight: bold;
+  font-size: 25px;
+  color: #333d4b;
+  margin-right: 10px;
+`;
+
+const PriceText = styled.span`
+  font-weight: 600;
+  font-size: 14px;
+  color: #4e5968;
+  margin-right: 6px;
+`;
+
+const PriceChange = styled.span`
+  font-weight: 600;
+  font-size: 14px;
+  color: #4e5968;
+`;

--- a/src/components/stocks/StockTrade.jsx
+++ b/src/components/stocks/StockTrade.jsx
@@ -1,0 +1,350 @@
+import { useState } from "react";
+import styled from "styled-components";
+
+const StockTrade = () => {
+  const [tradeType, setTradeType] = useState("BUY");
+  const [priceType, setPriceType] = useState("지정가");
+  const [inputPrice, setInputPrice] = useState("");
+  const [inputCount, setInputCount] = useState("");
+  const [isPriceFocused, setIsPriceFocused] = useState(false);
+  const [isCountFocused, setIsCountFocused] = useState(false);
+
+  const tradeTypes = [
+    {
+      value: "BUY",
+      korean: "매수",
+      color: "#f04452",
+      hoverColor: "#e42939",
+      label: "구매",
+    },
+    {
+      value: "SELL",
+      korean: "매도",
+      color: "#3182f6",
+      hoverColor: "#2272eb",
+      label: "판매",
+    },
+  ];
+
+  const priceTypes = ["지정가", "시장가"];
+
+  const activeTradeIndex = tradeTypes.findIndex((el) => el.value === tradeType);
+  const activePriceIndex = priceTypes.findIndex((el) => el === priceType);
+
+  const handleTradeType = (type) => () => {
+    setTradeType(type);
+  };
+
+  const handlePriceType = (type) => () => {
+    setPriceType(type);
+  };
+
+  const handleInputPriceChange = (e) => {
+    const value = e.target.value.replace(/[^0-9]/g, "");
+    setInputPrice(value);
+    setInputCount("1");
+  };
+
+  const formatPriceDisplay = () => {
+    return inputPrice ? parseInt(inputPrice, 10).toLocaleString() + " 원" : "";
+  };
+
+  const handleInputCountChange = (e) => {
+    const value = e.target.value.replace(/[^0-9]/g, "");
+    setInputCount(value);
+  };
+
+  const formatCountDisplay = () => {
+    return inputCount ? parseInt(inputCount, 10).toLocaleString() + " 주" : "";
+  };
+
+  return (
+    <StockTradeContainer>
+      <TradeTitle>주문하기</TradeTitle>
+      <TradeTypes>
+        <TradeHighlight $index={activeTradeIndex} />
+        {tradeTypes.map((el, index) => {
+          return (
+            <TradeType
+              key={index}
+              onClick={handleTradeType(el.value)}
+              $color={el.color}
+              $isActive={tradeType === el.value}
+            >
+              {el.korean}
+            </TradeType>
+          );
+        })}
+      </TradeTypes>
+      <TradeOrderForm>
+        <OrderLine>
+          <OrderLabel>{tradeTypes[activeTradeIndex].label} 가격</OrderLabel>
+          <PriceTypes>
+            <PriceHighlight $index={activePriceIndex} />
+            {priceTypes.map((el, index) => {
+              return (
+                <PriceType
+                  key={index}
+                  onClick={handlePriceType(el)}
+                  $isActive={priceType === el}
+                >
+                  {el}
+                </PriceType>
+              );
+            })}
+          </PriceTypes>
+        </OrderLine>
+        <OrderLine>
+          <OrderLabel />
+          {priceType === "지정가" ? (
+            <OrderInput
+              type="text"
+              value={isPriceFocused ? inputPrice : formatPriceDisplay()}
+              onChange={handleInputPriceChange}
+              placeholder="가격 입력"
+              onFocus={() => setIsPriceFocused(true)}
+              onBlur={() => setIsPriceFocused(false)}
+            />
+          ) : (
+            <OrderDisableInput>최대한 빠른 가격</OrderDisableInput>
+          )}
+        </OrderLine>
+        <OrderLine>
+          <OrderLabel>수량</OrderLabel>
+          <OrderInput
+            type="text"
+            value={isCountFocused ? inputCount : formatCountDisplay()}
+            onChange={handleInputCountChange}
+            placeholder="수량 입력"
+            onFocus={() => setIsCountFocused(true)}
+            onBlur={() => setIsCountFocused(false)}
+          />
+        </OrderLine>
+        <OrderInfoContainer>
+          <OrderInfo>
+            <OrderInfoSpan>구매 가능 금액</OrderInfoSpan>
+            <OrderInfoSpan>0 원</OrderInfoSpan>
+          </OrderInfo>
+          <OrderInfo>
+            <OrderInfoSpan>총 주문 금액</OrderInfoSpan>
+            <OrderInfoSpan>
+              {inputPrice && inputCount
+                ? `${(inputPrice * inputCount).toLocaleString()} 원`
+                : "0 원"}
+            </OrderInfoSpan>
+          </OrderInfo>
+        </OrderInfoContainer>
+        <TradeBtn
+          type="submit"
+          $color={tradeTypes[activeTradeIndex].color}
+          $hoverColor={tradeTypes[activeTradeIndex].hoverColor}
+        >
+          {tradeTypes[activeTradeIndex].label} 예약하기
+        </TradeBtn>
+      </TradeOrderForm>
+    </StockTradeContainer>
+  );
+};
+
+export default StockTrade;
+
+const StockTradeContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 30%;
+  gap: 8px;
+  margin-top: 48px;
+  height: 500px;
+  position: relative;
+`;
+
+const TradeTitle = styled.div`
+  font-weight: bold;
+  line-height: 1.45;
+  font-size: 14px;
+  color: #333d4b;
+`;
+
+const TradeTypes = styled.div`
+  display: flex;
+  padding: 2px;
+  border-radius: 8px;
+  justify-content: space-evenly;
+  align-items: center;
+  height: 32px;
+  background: #0220470d;
+  position: relative;
+  margin-bottom: 5px;
+`;
+
+const TradeHighlight = styled.div`
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: calc(50% - 2px);
+  height: calc(100% - 4px);
+  background: white;
+  border-radius: 6px;
+  box-shadow: #001b370a 0px 1px 3px 0px;
+  transition: transform 0.4s ease-in-out;
+  transform: ${({ $index }) => `translateX(${100 * $index}% )`};
+`;
+
+const TradeType = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-weight: 600;
+  line-height: 1.45;
+  font-size: 14px;
+  color: ${({ $isActive, $color }) => ($isActive ? $color : "#4e5968")};
+  width: 50%;
+  height: 100%;
+  cursor: pointer;
+  position: relative;
+  transition: 0.2s;
+`;
+
+const PriceTypes = styled.div`
+  display: flex;
+  padding: 2px;
+  border-radius: 8px;
+  justify-content: space-evenly;
+  align-items: center;
+  height: 32px;
+  background: #0220470d;
+  position: relative;
+  width: 100%;
+`;
+
+const PriceHighlight = styled.div`
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: calc(50% - 2px);
+  height: calc(100% - 4px);
+  background: white;
+  border-radius: 6px;
+  box-shadow: #001b370a 0px 1px 3px 0px;
+  transition: transform 0.4s ease-in-out;
+  transform: ${({ $index }) => `translateX(${100 * $index}% )`};
+`;
+
+const PriceType = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-weight: 600;
+  line-height: 1.45;
+  font-size: 14px;
+  color: ${({ $isActive, $color }) => ($isActive ? $color : "#4e5968")};
+  width: 50%;
+  height: 100%;
+  cursor: pointer;
+  position: relative;
+  transition: 0.2s;
+`;
+
+const TradeOrderForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+const OrderLine = styled.div`
+  display: flex;
+  gap: 8px;
+  padding: 0px 8px;
+`;
+
+const OrderLabel = styled.span`
+  display: flex;
+  align-items: center;
+  line-height: 33px;
+  min-width: 60px;
+  font-size: 14px;
+  line-height: 1.45;
+  font-weight: 600;
+  color: #333d4b;
+`;
+
+const OrderInput = styled.input`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 32px;
+  border-radius: 8px;
+  font-weight: 600;
+  color: #000c4dcc;
+  line-height: 20px;
+  font-size: 14px;
+  padding: 0px 14px;
+  border: 1px solid #dddddd;
+  transition: 0.1s;
+  &:hover {
+    border: 2px solid #000c4dcc;
+  }
+  &::placeholder {
+    font-size: 13px;
+    font-weight: 600;
+  }
+`;
+
+const OrderDisableInput = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 32px;
+  border-radius: 8px;
+  color: #03183275;
+  line-height: 20px;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 0px 14px;
+  background: #0220470d;
+  border: 1px solid #dddddd;
+`;
+
+const OrderInfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding-top: 70px;
+  margin-top: 70px;
+  border-top: 2px solid #001b370a;
+`;
+
+const OrderInfo = styled.div`
+  display: flex;
+  justify-content: space-between;
+  font-weight: bold;
+  color: #333d4b;
+  font-size: 14px;
+  line-height: 1.45px;
+  margin: 15px 8px;
+`;
+
+const OrderInfoSpan = styled.span``;
+
+const TradeBtn = styled.button`
+  font-family: pretendard;
+  min-height: 40px;
+  font-weight: 600;
+  text-align: center;
+  font-size: 15px;
+  line-height: 20px;
+  vertical-align: middle;
+  text-decoration: none;
+  border-radius: 10px;
+  background: ${({ $color }) => $color};
+  color: #fff;
+  transition: 0.2s;
+  border: none;
+  position: absolute;
+  left: 0px;
+  bottom: 20px;
+  width: 100%;
+  cursor: pointer;
+  &:hover {
+    background: ${({ $hoverColor }) => $hoverColor};
+  }
+`;

--- a/src/components/stocks/StockTrade.jsx
+++ b/src/components/stocks/StockTrade.jsx
@@ -269,6 +269,7 @@ const OrderLabel = styled.span`
 `;
 
 const OrderInput = styled.input`
+  font-family: pretendard;
   display: flex;
   align-items: center;
   width: 100%;

--- a/src/pages/Stocks.jsx
+++ b/src/pages/Stocks.jsx
@@ -1,10 +1,31 @@
 import StockChartContainer from "@/components/stocks/StockChartContainer";
+import StockHeader from "@/components/stocks/StockHeader";
+import StockTrade from "@/components/stocks/StockTrade";
 import { useLocation } from "react-router-dom";
+import styled from "styled-components";
 
 const Stocks = () => {
   const location = useLocation();
   const stock = location.state?.stock;
-  return <StockChartContainer stock={stock} />;
+  return (
+    <Container>
+      <StockHeader stock={stock} />
+      <StockContainer>
+        <StockChartContainer stock={stock} />
+        <StockTrade />
+      </StockContainer>
+    </Container>
+  );
 };
 
 export default Stocks;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding-top: 30px;
+`;
+
+const StockContainer = styled.div`
+  display: flex;
+`;


### PR DESCRIPTION
## 배경
- 매수 및 매도를 위한 UI 제작

## 작업 사항
- **기존 스타일 일부 변경** (d66da44ed7b89e22aa930b5d09378f45e1ad2b73)
  - 기존에 토스증권과 동일하게 주식 차트 화면에서는 배경색을 다르게 제작
  - 피그마 디자인과 차이가 있어 다시 피그마 디자인으로 변경
- **차트 스타일 변경 및 문구 추가** (e4a7c31c02dd7641adfbed14835659ac1cfb8694)
  - 차트 크기 변경
  - ETF, 선물 등의 종목 내에서는 문구 추가
- **거래를 위한 UI 제작** (150d592d12a97390e77223927fb151a8f01c6d90)
- **폰트 적용** (9938e596437ad7c30f703752470f6cd04f5cb4a6)
  
   ![image](https://github.com/user-attachments/assets/1fe4dc03-0380-4ed2-a156-6c54bb12c893)
   
   ![image](https://github.com/user-attachments/assets/100b7238-13fa-405c-8da3-b8176d7b51ec)

## 추가 논의
- API 연결이나 부족한 UI들은 웹소켓 연결 후 제작 예정입니다.
