### PR TITLE
Feature: 10분 단위 차트 구현

### DIFF
--- a/src/components/stocks/StockChart.jsx
+++ b/src/components/stocks/StockChart.jsx
@@ -7,7 +7,7 @@ import {
 } from "lightweight-charts";
 import styled from "styled-components";
 
-const StockChart = ({ chartData }) => {
+const StockChart = ({ chartData, period }) => {
   const chartContainerRef = useRef(null);
   const chartRef = useRef(null);
   const [tooltipData, setTooltipData] = useState(null);
@@ -196,7 +196,10 @@ const StockChart = ({ chartData }) => {
       };
 
       setTooltipData({
-        time: formatTimestampToDateTime(param.time),
+        time:
+          period === "MINUTE"
+            ? formatTimestampToDateTime(param.time)
+            : formatTimestampToDateTime(param.time).split(". 00")[0],
         open,
         high,
         low,
@@ -214,7 +217,7 @@ const StockChart = ({ chartData }) => {
       window.removeEventListener("resize", handleResize);
       chart.remove();
     };
-  }, [chartData]);
+  }, [period, chartData]);
 
   if (chartData.length === 0) {
     return <LoadingChart>지원하지 않는 차트입니다.</LoadingChart>;
@@ -258,6 +261,7 @@ StockChart.propTypes = {
       value: PropTypes.number.isRequired,
     })
   ).isRequired,
+  period: PropTypes.string.isRequired,
 };
 
 export default StockChart;

--- a/src/components/stocks/StockChart.jsx
+++ b/src/components/stocks/StockChart.jsx
@@ -62,6 +62,7 @@ const StockChart = ({ chartData, period }) => {
       timeScale: {
         visible: true,
         borderVisible: false,
+        timeVisible: period === "MINUTES" ? true : false,
       },
       rightPriceScale: {
         visible: true,
@@ -197,7 +198,7 @@ const StockChart = ({ chartData, period }) => {
 
       setTooltipData({
         time:
-          period === "MINUTE"
+          period === "MINUTES"
             ? formatTimestampToDateTime(param.time)
             : formatTimestampToDateTime(param.time).split(". 00")[0],
         open,

--- a/src/components/stocks/StockChart.jsx
+++ b/src/components/stocks/StockChart.jsx
@@ -94,7 +94,7 @@ const StockChart = ({ chartData }) => {
 
     candleSeries.setData(
       chartData.map((el) => ({
-        time: el.time,
+        time: Math.floor(new Date(el.time).getTime() / 1000),
         open: el.open,
         high: el.high,
         low: el.low,
@@ -103,7 +103,7 @@ const StockChart = ({ chartData }) => {
     );
     volumeSeries.setData(
       chartData.map((el) => ({
-        time: el.time,
+        time: Math.floor(new Date(el.time).getTime() / 1000),
         value: el.value,
         color: el.open < el.close ? "#f04452" : "#3182f6",
       }))
@@ -127,8 +127,12 @@ const StockChart = ({ chartData }) => {
     const totalDataPoints = chartData.length;
     if (totalDataPoints > 75) {
       chart.timeScale().setVisibleRange({
-        from: chartData[totalDataPoints - 75].time,
-        to: chartData[totalDataPoints - 1].time,
+        from: Math.floor(
+          new Date(chartData[totalDataPoints - 75].time).getTime() / 1000
+        ),
+        to: Math.floor(
+          new Date(chartData[totalDataPoints - 1].time).getTime() / 1000
+        ),
       });
     }
 
@@ -180,8 +184,19 @@ const StockChart = ({ chartData }) => {
           : null;
       };
 
+      const formatTimestampToDateTime = (timestamp) => {
+        return new Intl.DateTimeFormat("ko-KR", {
+          year: "numeric",
+          month: "2-digit",
+          day: "2-digit",
+          hour: "2-digit",
+          minute: "2-digit",
+          hour12: false,
+        }).format(new Date(timestamp * 1000));
+      };
+
       setTooltipData({
-        time: param.time,
+        time: formatTimestampToDateTime(param.time),
         open,
         high,
         low,

--- a/src/components/stocks/StockChartContainer.jsx
+++ b/src/components/stocks/StockChartContainer.jsx
@@ -106,7 +106,7 @@ const StockChartContainer = ({ stock }) => {
             })}
           </ChartPeriods>
         </ChartHeader>
-        <StockChart chartData={chartData} />
+        <StockChart chartData={chartData} period={period} />
       </ChartContainer>
     </StockContainer>
   );

--- a/src/components/stocks/StockChartContainer.jsx
+++ b/src/components/stocks/StockChartContainer.jsx
@@ -9,6 +9,7 @@ const StockChartContainer = ({ stock }) => {
   const [period, setPeriod] = useState("DAILY");
 
   const periods = [
+    { value: "MINUTES", korean: "10분" },
     { value: "DAILY", korean: "일" },
     { value: "WEEKLY", korean: "주" },
     { value: "MONTHLY", korean: "월" },
@@ -18,19 +19,63 @@ const StockChartContainer = ({ stock }) => {
   useEffect(() => {
     const fetchChartData = async () => {
       try {
-        const response = await getStocksChart({
-          stockCode: stock.stockCode,
-          period: period,
-        });
-        const transformedChartData = response.data.map((el) => ({
-          time: el.date,
-          open: el.open,
-          high: el.high,
-          low: el.low,
-          close: el.close,
-          value: el.volume,
-        }));
-        setChartData(transformedChartData);
+        if (period === "MINUTES") {
+          const now = new Date();
+          const hours = now.getHours();
+          const minutes = now.getMinutes();
+          const isTradingTime =
+            (hours === 9 && minutes >= 10) || (hours > 9 && hours < 16);
+
+          const requests = [
+            getStocksChart({
+              stockCode: stock.stockCode,
+              period: "MINUTES_WEEK",
+            }),
+          ];
+
+          if (isTradingTime) {
+            requests.push(
+              getStocksChart({
+                stockCode: stock.stockCode,
+                period: "MINUTES_TODAY",
+              })
+            );
+          }
+
+          const responses = await Promise.all(requests);
+
+          const transformData = (data) =>
+            data?.map((el) => ({
+              time: el.date,
+              open: el.open,
+              high: el.high,
+              low: el.low,
+              close: el.close,
+              value: el.volume,
+            })) || [];
+
+          const combinedData = responses.flatMap((response) =>
+            transformData(response.data)
+          );
+          combinedData.sort((a, b) => a.time - b.time);
+
+          setChartData(combinedData);
+        } else {
+          const response = await getStocksChart({
+            stockCode: stock.stockCode,
+            period,
+          });
+          const transformedData =
+            response?.data.map((el) => ({
+              time: el.date,
+              open: el.open,
+              high: el.high,
+              low: el.low,
+              close: el.close,
+              value: el.volume,
+            })) || [];
+          setChartData(transformedData);
+        }
       } catch (error) {
         console.error("주식 차트 데이터 가져오기 실패:", error.message);
       }


### PR DESCRIPTION
## 배경
- 주식 차트 화면 내에서 10분 단위 차트 출력 

## 작업 사항
- **`MINUTE` 선택 시 `WEEK`, `TODAY` 데이터를 합쳐서 차트에 넣도록 설정**(859e9be6f30449d4140e4940abee6a45daf897b3)
  - `MINUTE_TODAY` 의 경우 `09:00 ~ 16:00` 사이에만 요청하도록 설정
- **차트 내에 시간 단위 추가를 위한 시간 단위 변경**(a339d267a6edf6adef839b5ccd90493d9dc77412)
  - `YY-MM-DD` -> `UNIX 시간 단위`
- **10분 단위 차트 tooltip에서 시간 표시** (420f254687f4cf795ad4b2d7f3225315b9c77039)
- **10분 단위 차트 X축 시간으로 변경** (5b066031754ee7daf981605584caca4ab9becae1)
  ![image](https://github.com/user-attachments/assets/6a7d50ee-1114-420d-9854-51c4d63ac964)