### PR TITLE
Feature: 실시간 시세(체결 현황) 웹소켓 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "muzusi-web",
       "version": "0.0.0",
       "dependencies": {
+        "@stomp/stompjs": "^7.0.0",
         "axios": "^1.7.9",
         "lightweight-charts": "^5.0.1",
         "lodash": "^4.17.21",
@@ -15,6 +16,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^7.1.1",
+        "sockjs-client": "^1.6.1",
         "styled-components": "^6.1.13"
       },
       "devDependencies": {
@@ -1216,6 +1218,11 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@stomp/stompjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-7.0.0.tgz",
+      "integrity": "sha512-fGdq4wPDnSV/KyOsjq4P+zLc8MFWC3lMmP5FBgLWKPJTYcuCbAIrnRGjB7q2jHZdYCOD5vxLuFoKIYLy5/u8Pw=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -2611,6 +2618,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fancy-canvas": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fancy-canvas/-/fancy-canvas-2.1.0.tgz",
@@ -2633,6 +2648,17 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -2956,6 +2982,11 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/http-parser-js": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.9.tgz",
+      "integrity": "sha512-n1XsPy3rXVxlqxVioEWdC+0+M+SQw0DpJynwtOPo1X+ZlvdzTLtDBIJJlDQTnwZIFJrZSzSGmIOUdP8tu+SgLw=="
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2989,6 +3020,11 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
@@ -3586,8 +3622,7 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
       "version": "3.3.8",
@@ -3926,6 +3961,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -4041,6 +4081,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
     "node_modules/resolve": {
       "version": "2.0.0-next.5",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
@@ -4122,6 +4167,25 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.3",
@@ -4246,6 +4310,32 @@
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/sockjs-client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.6.1.tgz",
+      "integrity": "sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "eventsource": "^2.0.2",
+        "faye-websocket": "^0.11.4",
+        "inherits": "^2.0.4",
+        "url-parse": "^1.5.10"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://tidelift.com/funding/github/npm/sockjs-client"
+      }
+    },
+    "node_modules/sockjs-client/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
       }
     },
     "node_modules/source-map-js": {
@@ -4592,6 +4682,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/vite": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.3.tgz",
@@ -4675,6 +4774,27 @@
       },
       "peerDependencies": {
         "vite": ">=2.6.0"
+      }
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@stomp/stompjs": "^7.0.0",
     "axios": "^1.7.9",
     "lightweight-charts": "^5.0.1",
     "lodash": "^4.17.21",
@@ -17,6 +18,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.1.1",
+    "sockjs-client": "^1.6.1",
     "styled-components": "^6.1.13"
   },
   "devDependencies": {

--- a/src/components/stocks/LiveStockPrice.jsx
+++ b/src/components/stocks/LiveStockPrice.jsx
@@ -1,0 +1,148 @@
+import PropTypes from "prop-types";
+import styled from "styled-components";
+
+const LiveStockPrice = ({ messages }) => {
+  return (
+    <LivePriceContainer>
+      <LiveTitle>실시간 시세</LiveTitle>
+      <LiveTable>
+        <LiveThead>
+          <LiveTheadTr>
+            <LiveTheadTh style={{ width: "8%", justifyContent: "start" }}>
+              체결가
+            </LiveTheadTh>
+            <LiveTheadTh>체결량(주)</LiveTheadTh>
+            <LiveTheadTh>등락률</LiveTheadTh>
+            <LiveTheadTh>거래량(주)</LiveTheadTh>
+            <LiveTheadTh style={{ paddingRight: "20px" }}>시간</LiveTheadTh>
+          </LiveTheadTr>
+        </LiveThead>
+        <LiveTableContent>
+          {messages.map((el, index) => {
+            const formattedPrice = el.price.toLocaleString();
+            const formattedStockCount = el.stockCount.toLocaleString();
+            const formattedVolume = el.volume.toLocaleString();
+            return (
+              <LiveElement key={index}>
+                <LivePrice>{formattedPrice}</LivePrice>
+                <LiveChange $tradeType={el.tradeType}>
+                  {formattedStockCount}
+                </LiveChange>
+                <LiveChange $tradeType={el.tradeType}>
+                  {el.changeRate}%
+                </LiveChange>
+                <LiveEnd>{formattedVolume}</LiveEnd>
+                <LiveEnd style={{ paddingRight: "5px" }}>{el.time}</LiveEnd>
+              </LiveElement>
+            );
+          })}
+        </LiveTableContent>
+      </LiveTable>
+    </LivePriceContainer>
+  );
+};
+
+LiveStockPrice.propTypes = {
+  messages: PropTypes.array.isRequired,
+};
+
+export default LiveStockPrice;
+
+const LivePriceContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const LiveTitle = styled.div`
+  font-weight: bold;
+  color: #333d4b;
+  font-size: 14px;
+  margin-top: 20px;
+`;
+
+const LiveTable = styled.table`
+  display: table;
+  border-collapse: separate;
+  width: 100%;
+`;
+
+const LiveThead = styled.thead`
+  width: 100%;
+`;
+
+const LiveTheadTr = styled.tr`
+  display: flex;
+  width: 100%;
+  border-bottom: 1px solid #dddddd;
+`;
+
+const LiveTheadTh = styled.th`
+  color: #6b7684;
+  display: flex;
+  justify-content: end;
+  align-items: center;
+  font-weight: 500;
+  min-height: 30px;
+  line-height: 1.5;
+  font-size: 12px;
+  width: 23%;
+`;
+
+const LiveTableContent = styled.tbody`
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding-top: 5px;
+  width: 100%;
+  max-height: 100px;
+  overflow-y: auto;
+`;
+
+const LiveElement = styled.tr`
+  display: flex;
+  width: 100%;
+  align-items: center;
+  border-radius: 5px;
+  cursor: pointer;
+  &:hover {
+    background: #f6f7f9;
+  }
+`;
+
+const LivePrice = styled.th`
+  display: flex;
+  width: 8%;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  word-break: break-all;
+  font-weight: 400;
+  font-size: 12px;
+  color: #4e5968;
+`;
+
+const LiveChange = styled.th`
+  display: flex;
+  justify-content: end;
+  width: 23%;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  word-break: break-all;
+  font-weight: 400;
+  font-size: 12px;
+  color: ${({ $tradeType }) => ($tradeType === "BUY" ? "#f04452" : "#3182f6")};
+`;
+
+const LiveEnd = styled.th`
+  display: flex;
+  justify-content: end;
+  width: 23%;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  word-break: break-all;
+  font-weight: 400;
+  font-size: 12px;
+  color: #4e5968;
+`;

--- a/src/config/Env.jsx
+++ b/src/config/Env.jsx
@@ -3,3 +3,4 @@ export const naverClientId = import.meta.env.VITE_NAVER_REST_API_KEY;
 export const kakaoRedirectUri = import.meta.env.VITE_KAKAO_REDIRECT_URI;
 export const naverRedirectUri = import.meta.env.VITE_NAVER_REDIRECT_URI;
 export const baseUrl = import.meta.env.VITE_SERVER_BASE_URL;
+export const webSocketUrl = import.meta.env.VITE_WEB_SOCKET_URL;

--- a/src/pages/Stocks.jsx
+++ b/src/pages/Stocks.jsx
@@ -21,6 +21,7 @@ const Stocks = () => {
   const [period, setPeriod] = useState("DAILY");
   const [messages, setMessages] = useState([]);
   const subscriptionRef = useRef(null);
+  const clientRef = useRef(null);
 
   const periods = [
     { value: "MINUTES", korean: "10분" },
@@ -58,21 +59,41 @@ const Stocks = () => {
     });
 
     client.activate();
+    clientRef.current = client;
+
+    const unsubscribeAndDisconnect = () => {
+      if (subscriptionRef.current) {
+        clientRef.current.unsubscribe(subscriptionRef.current.id, {
+          stockCode: stock.stockCode,
+        });
+        subscriptionRef.current = null;
+      }
+
+      if (clientRef.current.connected) {
+        clientRef.current.deactivate();
+      }
+    };
+
+    const handleBeforeUnload = () => {
+      console.log("⚠️ 브라우저 창이 닫힘, 구독 해제 진행");
+      unsubscribeAndDisconnect();
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
 
     return () => {
       if (subscriptionRef.current) {
-        client.publish({
-          destination: "/app/unsubscribe",
-          body: JSON.stringify({ stockCode: stock.stockCode }),
-          headers: { stockCode: stock.stockCode },
-        });
-
         client.unsubscribe(subscriptionRef.current.id, {
           stockCode: stock.stockCode,
         });
 
         subscriptionRef.current = null;
       }
+
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+
+      unsubscribeAndDisconnect();
+
       if (client.connected) {
         client.deactivate();
       }

--- a/src/pages/Stocks.jsx
+++ b/src/pages/Stocks.jsx
@@ -1,11 +1,15 @@
 import getStocksChart from "@/api/stocks/getStockChart";
 import Error from "@/components/common/Error";
 import Loading from "@/components/common/Loading";
+import LiveStockPrice from "@/components/stocks/LiveStockPrice";
 import StockChartContainer from "@/components/stocks/StockChartContainer";
 import StockHeader from "@/components/stocks/StockHeader";
 import StockTrade from "@/components/stocks/StockTrade";
-import { useEffect, useState } from "react";
+import { webSocketUrl } from "@/config/Env";
+import { Client } from "@stomp/stompjs";
+import { useEffect, useRef, useState } from "react";
 import { useLocation } from "react-router-dom";
+import SockJS from "sockjs-client";
 import styled from "styled-components";
 
 const Stocks = () => {
@@ -15,6 +19,8 @@ const Stocks = () => {
   const [error, setError] = useState(null);
   const [chartData, setChartData] = useState([]);
   const [period, setPeriod] = useState("DAILY");
+  const [messages, setMessages] = useState([]);
+  const subscriptionRef = useRef(null);
 
   const periods = [
     { value: "MINUTES", korean: "10분" },
@@ -23,6 +29,57 @@ const Stocks = () => {
     { value: "MONTHLY", korean: "월" },
     { value: "YEARLY", korean: "년" },
   ];
+
+  useEffect(() => {
+    const socket = new SockJS(webSocketUrl.replace(/^ws/, "http"));
+    const client = new Client({
+      webSocketFactory: () => socket,
+      reconnectDelay: 5000,
+
+      onConnect: () => {
+        if (subscriptionRef.current) {
+          subscriptionRef.current.unsubscribe();
+        }
+
+        subscriptionRef.current = client.subscribe(
+          `/sub/${stock.stockCode}`,
+          (message) => {
+            const parsedMessage = JSON.parse(message.body);
+            setMessages((prev) => {
+              [...prev, parsedMessage];
+            });
+          },
+          {
+            stockCode: stock.stockCode,
+          }
+        );
+      },
+      onStompError: (frame) => {
+        console.error("STOMP Error 발생:", frame);
+      },
+    });
+
+    client.activate();
+
+    return () => {
+      if (subscriptionRef.current) {
+        client.publish({
+          destination: "/app/unsubscribe",
+          body: JSON.stringify({ stockCode: stock.stockCode }),
+          headers: { stockCode: stock.stockCode },
+        });
+
+        client.unsubscribe(subscriptionRef.current.id, {
+          stockCode: stock.stockCode,
+        });
+
+        subscriptionRef.current = null;
+      }
+      if (client.connected) {
+        client.deactivate();
+      }
+    };
+  }, [stock?.stockCode]);
 
   useEffect(() => {
     const fetchChartData = async () => {
@@ -114,6 +171,7 @@ const Stocks = () => {
         />
         <StockTrade />
       </StockContainer>
+      <LiveStockPrice messages={messages} />
     </Container>
   );
 };

--- a/src/pages/Stocks.jsx
+++ b/src/pages/Stocks.jsx
@@ -45,9 +45,7 @@ const Stocks = () => {
           `/sub/${stock.stockCode}`,
           (message) => {
             const parsedMessage = JSON.parse(message.body);
-            setMessages((prev) => {
-              [...prev, parsedMessage];
-            });
+            setMessages((prev) => [parsedMessage, ...prev]);
           },
           {
             stockCode: stock.stockCode,

--- a/src/pages/Stocks.jsx
+++ b/src/pages/Stocks.jsx
@@ -31,7 +31,16 @@ const Stocks = () => {
     { value: "YEARLY", korean: "년" },
   ];
 
+  const now = new Date();
+  const hours = now.getHours();
+  const minutes = now.getMinutes();
+  const isTradingTime =
+    (hours === 9 && minutes >= 0) ||
+    (hours > 9 && (hours < 15 || (hours === 15 && minutes <= 30)));
+
   useEffect(() => {
+    if (!isTradingTime) return;
+
     const socket = new SockJS(webSocketUrl.replace(/^ws/, "http"));
     const client = new Client({
       webSocketFactory: () => socket,
@@ -75,7 +84,6 @@ const Stocks = () => {
     };
 
     const handleBeforeUnload = () => {
-      console.log("⚠️ 브라우저 창이 닫힘, 구독 해제 진행");
       unsubscribeAndDisconnect();
     };
 
@@ -98,18 +106,12 @@ const Stocks = () => {
         client.deactivate();
       }
     };
-  }, [stock?.stockCode]);
+  }, [stock?.stockCode, isTradingTime]);
 
   useEffect(() => {
     const fetchChartData = async () => {
       try {
         if (period === "MINUTES") {
-          const now = new Date();
-          const hours = now.getHours();
-          const minutes = now.getMinutes();
-          const isTradingTime =
-            (hours === 9 && minutes >= 10) || (hours > 9 && hours < 16);
-
           const requests = [
             getStocksChart({
               stockCode: stock.stockCode,
@@ -169,7 +171,7 @@ const Stocks = () => {
     };
 
     fetchChartData();
-  }, [stock.stockCode, period]);
+  }, [stock.stockCode, period, isTradingTime]);
 
   const handlePeriod = (period) => () => {
     setPeriod(period);

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,4 +13,7 @@ export default defineConfig({
       "@": "/src",
     },
   },
+  define: {
+    global: "window",
+  },
 });


### PR DESCRIPTION
## 배경
- 실시간 시세(체결가, 체결량, 등락률, 거래량, 시간)을 수신하는 웹소켓 적용

## 작업 사항
- **필요 라이브러리 설치**(5343384588d4997e3ec88ce671233f10333b058c)
  - SockJS, STOMP
- **global 변수 선언**(c8b67ffe4d4cbf187fef9ef9abb4e04aa5097730)
  - VITE 프로젝트의 경우 SockJS 사용을 위해 별도의 선언 필요
- **웹 소켓 주소 환경변수 추가**(14b9e6374cd549ba9835cd9a43b831075f0d7770)
- **웹소켓 적용**(04f39e1196892b0203ed2a6e819e40a72ce392a9)
  - 구독 시 `subscsribe` 헤더에 `stockCode` 포함하여 전송
  - 구독 해제 시 `unsubscribe` 헤더에 `stockCode` 포함하여 전송
- **UI 구현**(c2bd7e357e988fd5f8778f11638256aa4a067c46)
  - 주식장 종료 이슈로 인해 임의의 데이터로 테스트.
  ![image](https://github.com/user-attachments/assets/b99027ae-1bbc-463a-93c9-86b114616bd4)
- **체결가 최신순 정렬**(bb7002a3706a1eae9c62d839aa76257211023939)
- **창 종료시 `unsubscribe` 전송**(67f52ee9a775e400ddb7e73228ecbb488f2cc621)
- **장 시간 내(09:00 ~ 15:30)에만 웹소켓 연결**(8e8ea92b78ac08f898985c4a91ed70bc4f4b0aef)

## 추가 논의
- STOMP 버전 변경으로 인한 `disconnect` 함수 미지원으로 인해 `unsubscribe`에 헤더를 담아 전송하는 것으로 변경하였습니다.
