### PR TITLE
Feature: 자산 차트 출력

### DIFF
--- a/src/components/account/AccountChart.jsx
+++ b/src/components/account/AccountChart.jsx
@@ -1,0 +1,68 @@
+import { createChart, LineSeries } from "lightweight-charts";
+import PropTypes from "prop-types";
+import { useEffect, useRef } from "react";
+import styled from "styled-components";
+
+const AccountChart = ({ chartData }) => {
+  const chartContainerRef = useRef(null);
+
+  useEffect(() => {
+    if (!chartContainerRef || !chartData.length) return;
+
+    const chart = createChart(chartContainerRef.current, {
+      width: chartContainerRef.current.clientWdith,
+      height: 300,
+      layout: {
+        backgroundColor: "#ffffff",
+        textColor: "#000000",
+      },
+      grid: {
+        vertLines: { visible: false },
+        horzLines: { visible: false },
+      },
+      timeScale: {
+        borderVisible: false,
+      },
+      rightPriceScale: {
+        visible: false,
+      },
+    });
+
+    const lineSeries = chart.addSeries(LineSeries, {
+      color: "#E75151",
+      lineWidth: 2,
+    });
+
+    const formattedData = chartData.reverse().map((item) => ({
+      time: item.createdAt,
+      value: item.totalBalance,
+    }));
+
+    lineSeries.setData(formattedData);
+    chart.timeScale().fitContent();
+
+    return () => {
+      chart.remove();
+    };
+  }, [chartData]);
+
+  return <AccountChartContainer ref={chartContainerRef} />;
+};
+
+AccountChart.propTypes = {
+  chartData: PropTypes.arrayOf(
+    PropTypes.shape({
+      totalBalance: PropTypes.number.isRequired,
+      createdAt: PropTypes.string.isRequired,
+    })
+  ),
+};
+
+export default AccountChart;
+
+const AccountChartContainer = styled.div`
+  display: flex;
+  height: 300px;
+  width: 100%;
+  justify-content: center;
+`;

--- a/src/components/account/CurrentAccount.jsx
+++ b/src/components/account/CurrentAccount.jsx
@@ -3,7 +3,8 @@ import getCurrentAccount from "@/api/account/getCurrentAccount";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
 import Loading from "@/components/common/Loading";
-import Error from "../common/Error";
+import Error from "@/components/common/Error";
+import AccountChart from "@/components/account/AccountChart";
 
 const CurrentAccount = () => {
   const [currentAccount, setCurrentAccount] = useState([]);
@@ -51,6 +52,17 @@ const CurrentAccount = () => {
     }
   };
 
+  const accountProfits = currentAccount?.accountProfits || [];
+  const hasEnoughData = accountProfits.length >= 2;
+
+  const previousBalance = hasEnoughData ? accountProfits[0].totalBalance : 0;
+  const currentBalance = hasEnoughData ? accountProfits[1].totalBalance : 0;
+
+  const balanceChange = currentBalance - previousBalance;
+  const balanceChangeRate = previousBalance
+    ? ((balanceChange / previousBalance) * 100).toFixed(2)
+    : "0.00";
+
   useEffect(() => {
     fetchCurrentAccount();
   }, []);
@@ -68,7 +80,17 @@ const CurrentAccount = () => {
           </CreateAccountBtn>
         </BalanceHeader>
         <Balance>{totalAsset.toLocaleString()} 원</Balance>
+        {hasEnoughData ? (
+          <BalanceChange>
+            이 전날보다{" "}
+            <BalanceChangeRate $change={balanceChange}>
+              {balanceChange > 0 ? "+" : ""}
+              {balanceChange.toLocaleString()}({balanceChangeRate}%)
+            </BalanceChangeRate>
+          </BalanceChange>
+        ) : null}
       </BalanceContainer>
+      <AccountChart chartData={currentAccount.accountProfits} />
       <AssetsContainer>
         <AssetContainer>
           <Title>주문 가능 금액</Title>
@@ -129,6 +151,18 @@ const Balance = styled.div`
   color: #333d4b;
   line-height: 1.45;
   font-size: 24px;
+`;
+
+const BalanceChange = styled.div`
+  font-weight: 500;
+  color: #4e5968;
+  font-size: 15px;
+  line-height: 1.45;
+`;
+
+const BalanceChangeRate = styled.span`
+  color: ${({ $change }) =>
+    $change > 0 ? "#f04452" : $change < 0 ? "#3182f6" : "#4e5968"};
 `;
 
 const AssetsContainer = styled.div`


### PR DESCRIPTION
## 배경
- '내 계좌 - 자산` 페이지 내에서 최근 14일 내 총 잔고 차트 출력

## 작업 사항
- **잔고 차트 구현** (881820c4c6e18c3a84f321cf028b8549c6f535bc)
  - 최근 14일의 데이터 기반
  - 꺾은선 그래프
- **전날 대비 수익률 출력** (0df91908d7318d51af51539bee67a0287e934938)
  ![image](https://github.com/user-attachments/assets/5c46652d-bdfe-4a89-ad2e-fa355b5eac4a)

## 추가 논의
- 추후 주식 매수, 매도 진행 후에 정상 작동 테스트 예정입니다.
