### PR TITLE
Fix: 자산 페이지 내 일부 수정

### DIFF
--- a/src/components/account/AccountRecords.jsx
+++ b/src/components/account/AccountRecords.jsx
@@ -9,6 +9,18 @@ const AccountRecords = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
 
+  const formatDateTime = (dateString) => {
+    const date = new Date(dateString);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    const hours = String(date.getHours()).padStart(2, "0");
+    const minutes = String(date.getMinutes()).padStart(2, "0");
+    const seconds = String(date.getSeconds()).padStart(2, "0");
+
+    return `${year}년 ${month}월 ${day}일 ${hours}:${minutes}:${seconds}`;
+  };
+
   const fetchAccountRecords = async () => {
     try {
       const response = await getAccountRecords();
@@ -44,16 +56,18 @@ const AccountRecords = () => {
           </RecordTheadTr>
         </RecordThead>
         <RecordTableContent>
-          {accountRecords.map((el, index) => {
+          {accountRecords.reverse().map((el, index) => {
             const formattedBalance = el.balance.toLocaleString();
-            const formattedDate = el.createdAt.split(".")[0].replace("T", " ");
+
             const change = ((el.balance - 10000000) / 10000000) * 100;
             return (
               <RecordTableAccount key={el.id} $isOdd={(index + 1) % 2 !== 0}>
                 <AccountNumber>{index + 1}</AccountNumber>
-                <AccountDate>{formattedDate}8</AccountDate>
+                <AccountDate>{formatDateTime(el.createdAt)}</AccountDate>
                 <AccountPrice>{formattedBalance}원</AccountPrice>
-                <AccountChange $change={change}>{change}%</AccountChange>
+                <AccountChange $change={change}>
+                  {change.toFixed(2)}%
+                </AccountChange>
               </RecordTableAccount>
             );
           })}

--- a/src/components/account/CurrentAccount.jsx
+++ b/src/components/account/CurrentAccount.jsx
@@ -11,8 +11,6 @@ const CurrentAccount = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const totalAsset = currentAccount.balance + currentAccount.reservedPrice;
-
   const fetchCurrentAccount = async () => {
     try {
       const response = await getCurrentAccount();
@@ -79,7 +77,7 @@ const CurrentAccount = () => {
             초기화 및 계좌 재생성
           </CreateAccountBtn>
         </BalanceHeader>
-        <Balance>{totalAsset.toLocaleString()} 원</Balance>
+        <Balance>{accountProfits[1].totalBalance.toLocaleString()} 원</Balance>
         {hasEnoughData ? (
           <BalanceChange>
             이 전날보다{" "}


### PR DESCRIPTION
## 배경
- 현재 내 자산에서 계좌의 잔고만 출력되는 현상 발견

## 작업 사항
- **`계좌의 잔고 -> 잔고 + 보유 주식 가격`으로 변경**(56f783fd7e082ed72500936513e5a7dccab6c44c)
- **전체 계좌 기록 날짜 형식 변경**(5b8eeca565e7595a7afaa8157e131d905bc26bbf)
  - `YY-MM-DD -> YY년 MM월 DD일`로 변경
  - 일부 오타 수정
