### PR TITLE
Feature: 실시간 체결가 기반 현재가 출력

### DIFF
--- a/src/components/stocks/LiveStockPrice.jsx
+++ b/src/components/stocks/LiveStockPrice.jsx
@@ -1,5 +1,6 @@
 import PropTypes from "prop-types";
 import styled from "styled-components";
+import MuLogo from "@/assets/logo/MuLogo.webp";
 
 const LiveStockPrice = ({ messages }) => {
   return (
@@ -17,27 +18,37 @@ const LiveStockPrice = ({ messages }) => {
             <LiveTheadTh style={{ paddingRight: "20px" }}>시간</LiveTheadTh>
           </LiveTheadTr>
         </LiveThead>
-        <LiveTableContent>
-          {messages.map((el, index) => {
-            const formattedPrice = el.price.toLocaleString();
-            const formattedStockCount = el.stockCount.toLocaleString();
-            const formattedVolume = el.volume.toLocaleString();
-            return (
-              <LiveElement key={index}>
-                <LivePrice>{formattedPrice}</LivePrice>
-                <LiveChange $tradeType={el.tradeType}>
-                  {formattedStockCount}
-                </LiveChange>
-                <LiveChange $tradeType={el.tradeType}>
-                  {el.changeRate}%
-                </LiveChange>
-                <LiveEnd>{formattedVolume}</LiveEnd>
-                <LiveEnd style={{ paddingRight: "5px" }}>{el.time}</LiveEnd>
-              </LiveElement>
-            );
-          })}
-        </LiveTableContent>
+        {messages.length > 0 ? (
+          <LiveTableContent>
+            {messages.map((el, index) => {
+              const formattedPrice = el.price.toLocaleString();
+              const formattedStockCount = el.stockCount.toLocaleString();
+              const formattedVolume = el.volume.toLocaleString();
+              return (
+                <LiveElement key={index}>
+                  <LivePrice>{formattedPrice}</LivePrice>
+                  <LiveChange $tradeType={el.tradeType}>
+                    {formattedStockCount}
+                  </LiveChange>
+                  <LiveChange $tradeType={el.tradeType}>
+                    {el.changeRate}%
+                  </LiveChange>
+                  <LiveEnd>{formattedVolume}</LiveEnd>
+                  <LiveEnd style={{ paddingRight: "5px" }}>{el.time}</LiveEnd>
+                </LiveElement>
+              );
+            })}
+          </LiveTableContent>
+        ) : null}
       </LiveTable>
+      {messages.length > 0 ? null : (
+        <Notice>
+          <Logo src={MuLogo} alt="MuLogo" />
+          현재 장 시간이 아닙니다.
+          <br />
+          (9:00 ~ 13:30)
+        </Notice>
+      )}
     </LivePriceContainer>
   );
 };
@@ -145,4 +156,20 @@ const LiveEnd = styled.th`
   font-weight: 400;
   font-size: 12px;
   color: #4e5968;
+`;
+
+const Notice = styled.div`
+  width: 100%;
+  min-height: 100px;
+  display: flex;
+  gap: 5px;
+  justify-content: center;
+  align-items: end;
+  font-size: 15px;
+  font-weight: 600;
+`;
+
+const Logo = styled.img`
+  width: 50px;
+  height: auto;
 `;

--- a/src/components/stocks/StockChart.jsx
+++ b/src/components/stocks/StockChart.jsx
@@ -196,6 +196,7 @@ const StockChart = ({ chartData, period }) => {
           hour: "2-digit",
           minute: "2-digit",
           hour12: false,
+          timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
         }).format(new Date(timestamp * 1000));
       };
 
@@ -282,7 +283,7 @@ const Chart = styled.div`
 
 const TooltipContainer = styled.div`
   position: absolute;
-  top: -30px;
+  top: -10px;
   font-size: 12px;
   z-index: 1000;
   pointer-events: none;

--- a/src/components/stocks/StockHeader.jsx
+++ b/src/components/stocks/StockHeader.jsx
@@ -1,7 +1,29 @@
 import PropTypes from "prop-types";
+import { useEffect, useState } from "react";
 import styled from "styled-components";
 
-const StockHeader = ({ stock }) => {
+const StockHeader = ({ stock, currentPrice, yesterdayData }) => {
+  const [change, setChange] = useState(0);
+  const [changeRate, setChangeRate] = useState(0);
+  const [yesterdayPrice, setYesterdayPrice] = useState(0);
+
+  const formatDate = (dateString) => {
+    const date = new Date(dateString);
+    const month = String(date.getMonth() + 1);
+    const day = String(date.getDate());
+
+    return `${month}월 ${day}일`;
+  };
+
+  useEffect(() => {
+    setYesterdayPrice(yesterdayData.close);
+  }, [yesterdayData.close]);
+
+  useEffect(() => {
+    setChange(currentPrice - yesterdayPrice);
+    setChangeRate(((currentPrice - yesterdayPrice) / yesterdayPrice) * 100);
+  }, [currentPrice, yesterdayPrice]);
+
   return (
     <StockHeaderContainer>
       <StockInfo>
@@ -9,9 +31,12 @@ const StockHeader = ({ stock }) => {
         <StockCode>{stock.stockCode}</StockCode>
       </StockInfo>
       <StockPrice>
-        <CurrentPrice>000원</CurrentPrice>
-        <PriceText>어제보다</PriceText>
-        <PriceChange>0원 (0.0)%</PriceChange>
+        <CurrentPrice>{currentPrice.toLocaleString()}원</CurrentPrice>
+        <PriceText>{formatDate(yesterdayData.date)}보다</PriceText>
+        <PriceChange $change={change}>
+          {change > 0 ? `+${change.toLocaleString()}` : change.toLocaleString()}
+          원 ({changeRate.toFixed(2)}%)
+        </PriceChange>
       </StockPrice>
     </StockHeaderContainer>
   );
@@ -22,6 +47,9 @@ StockHeader.propTypes = {
     stockName: PropTypes.string.isRequired,
     stockCode: PropTypes.string.isRequired,
   }),
+  currentPrice: PropTypes.number.isRequired,
+  yesterdayData: PropTypes.object.isRequired,
+  messages: PropTypes.array.isRequired,
 };
 
 export default StockHeader;
@@ -41,12 +69,12 @@ const StockInfo = styled.div`
 `;
 
 const StockName = styled.span`
-  font-weight: 600;
+  font-weight: 500;
   color: #333d4b;
 `;
 
 const StockCode = styled.span`
-  font-weight: 500;
+  font-weight: 400;
   color: #8b95a1;
 `;
 
@@ -57,21 +85,23 @@ const StockPrice = styled.div`
 `;
 
 const CurrentPrice = styled.span`
-  font-weight: bold;
+  font-weight: 600;
   font-size: 25px;
   color: #333d4b;
   margin-right: 10px;
 `;
 
 const PriceText = styled.span`
-  font-weight: 600;
+  font-weight: 500;
   font-size: 14px;
-  color: #4e5968;
+  color: ${({ $change }) =>
+    $change > 0 ? "#f04452" : $change < 0 ? "#3182f6" : "#4e5968"};
   margin-right: 6px;
 `;
 
 const PriceChange = styled.span`
-  font-weight: 600;
+  font-weight: 500;
   font-size: 14px;
-  color: #4e5968;
+  color: ${({ $change }) =>
+    $change > 0 ? "#f04452" : $change < 0 ? "#3182f6" : "#4e5968"};
 `;

--- a/src/pages/Stocks.jsx
+++ b/src/pages/Stocks.jsx
@@ -18,10 +18,13 @@ const Stocks = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
   const [chartData, setChartData] = useState([]);
-  const [period, setPeriod] = useState("DAILY");
+  const [period, setPeriod] = useState("MINUTES");
   const [messages, setMessages] = useState([]);
   const subscriptionRef = useRef(null);
   const clientRef = useRef(null);
+  const isFirstSet = useRef(true);
+  const [yesterdayData, setYesterdayData] = useState({});
+  const [currentPrice, setCurrentPrice] = useState(0);
 
   const periods = [
     { value: "MINUTES", korean: "10분" },
@@ -37,6 +40,31 @@ const Stocks = () => {
   const isTradingTime =
     (hours === 9 && minutes >= 0) ||
     (hours > 9 && (hours < 15 || (hours === 15 && minutes <= 30)));
+
+  useEffect(() => {
+    const fetchYesterdayPrice = async () => {
+      try {
+        const response = await getStocksChart({
+          stockCode: stock.stockCode,
+          period: "DAILY",
+        });
+        setYesterdayData(response.data[response.data.length - 2]);
+      } catch (error) {
+        console.error("주식 차트 데이터 가져오기 실패:", error.message);
+        setError(error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchYesterdayPrice();
+  }, [stock.stockCode]);
+
+  useEffect(() => {
+    if (isFirstSet.current && chartData.length > 0) {
+      isFirstSet.current = false;
+      setCurrentPrice(chartData[chartData.length - 1].close);
+    }
+  }, [chartData]);
 
   useEffect(() => {
     if (!isTradingTime) return;
@@ -56,6 +84,7 @@ const Stocks = () => {
           (message) => {
             const parsedMessage = JSON.parse(message.body);
             setMessages((prev) => [parsedMessage, ...prev]);
+            setCurrentPrice(parsedMessage.price);
           },
           {
             stockCode: stock.stockCode,
@@ -182,7 +211,12 @@ const Stocks = () => {
 
   return (
     <Container>
-      <StockHeader stock={stock} />
+      <StockHeader
+        stock={stock}
+        currentPrice={currentPrice}
+        yesterdayData={yesterdayData}
+        messages={messages}
+      />
       <StockContainer>
         <StockChartContainer
           period={period}


### PR DESCRIPTION
## 배경
- 실시간 체결가를 기반으로 현재가를 출력

## 작업 사항
- **현재가 받아오기**(7005c188544edcba6507658a2852096f300c9934)
  - 장 시간에는 가장 최근 체결가
  - 장 시간 외에는 분봉차트 마지막 종가
- **현재가 및 전날 대비 변화율 추가**(1fdf30b802ce81e899a9eb47030bee084eebffc7)
- **장 시간 외에 실시간 체결가 안내 메세지 출력**(843dda7faae24a262f9083656b311ac7f64d3041)
- **시간대 통일**(26b885fe240a3fba86266cb91e26538dc3a7b9d7)
  - 이전에 차트(KST)와 tooltip(UTC)의 시간의 시간대 차이로 하루 차이가 나는 현상 발견
  - KST로 통일하여 해결
  ![image](https://github.com/user-attachments/assets/4d564653-66fa-4e33-a1c2-d002fe259b15)

