### PR TITLE
Fix: 계좌 잔고 출력 수정

### DIFF
--- a/src/components/account/CurrentAccount.jsx
+++ b/src/components/account/CurrentAccount.jsx
@@ -187,13 +187,12 @@ const AssetContainer = styled.div`
   padding: 20px 24px;
   background: #f9fafb;
   border-radius: 15px;
-  gap: 12px;
 `;
 
 const AvailableBalance = styled.div`
   display: flex;
   flex-direction: column;
-  font-weight: 600;
+  font-weight: 500;
   color: #333d4b;
   line-height: 1.45;
   font-size: 20px;

--- a/src/components/account/CurrentAccount.jsx
+++ b/src/components/account/CurrentAccount.jsx
@@ -53,8 +53,8 @@ const CurrentAccount = () => {
   const accountProfits = currentAccount?.accountProfits || [];
   const hasEnoughData = accountProfits.length >= 2;
 
-  const previousBalance = hasEnoughData ? accountProfits[0].totalBalance : 0;
-  const currentBalance = hasEnoughData ? accountProfits[1].totalBalance : 0;
+  const previousBalance = hasEnoughData ? accountProfits[1].totalBalance : 0;
+  const currentBalance = hasEnoughData ? accountProfits[0].totalBalance : 0;
 
   const balanceChange = currentBalance - previousBalance;
   const balanceChangeRate = previousBalance
@@ -77,7 +77,7 @@ const CurrentAccount = () => {
             초기화 및 계좌 재생성
           </CreateAccountBtn>
         </BalanceHeader>
-        <Balance>{accountProfits[1].totalBalance.toLocaleString()} 원</Balance>
+        <Balance>{accountProfits[0].totalBalance.toLocaleString()} 원</Balance>
         {hasEnoughData ? (
           <BalanceChange>
             이 전날보다{" "}
@@ -98,7 +98,17 @@ const CurrentAccount = () => {
         </AssetContainer>
         <AssetContainer>
           <Title>투자 중인 금액</Title>
-          <AvailableBalance>- 원</AvailableBalance>
+          <AvailableBalance>
+            {currentAccount.totalEvaluatedAmount.toLocaleString()}원
+            <Return $return={currentAccount.totalProfitAmount}>
+              {currentAccount.totalProfitAmount > 0
+                ? `+ ${currentAccount.totalProfitAmount.toLocaleString()}`
+                : `- ${Math.abs(
+                    currentAccount.totalProfitAmount
+                  ).toLocaleString()}`}
+              원 ({Math.abs(currentAccount.totalRateOfReturn)}%)
+            </Return>
+          </AvailableBalance>
         </AssetContainer>
       </AssetsContainer>
     </CurrentAccountContainer>
@@ -181,8 +191,19 @@ const AssetContainer = styled.div`
 `;
 
 const AvailableBalance = styled.div`
+  display: flex;
+  flex-direction: column;
   font-weight: 600;
   color: #333d4b;
   line-height: 1.45;
   font-size: 20px;
+`;
+
+const Return = styled.div`
+  display: flex;
+  font-weight: normal;
+  line-height: 1.45;
+  font-size: 14px;
+  color: ${({ $return }) =>
+    $return > 0 ? "#f04452" : $return < 0 ? "#3182f6" : "#4e5968"};
 `;


### PR DESCRIPTION
## 배경
- 계좌 잔고와 전날 대비 변화율이 제대로 출력되지 않는 현상 발견

## 작업 사항
- **계좌 잔고 및 변화율 수정**(418bde81c27b9c91295e53dfda2bc989be8ef174)
  - 배열 내 인덱스 설정 오류 수정
- **투자 중인 금액 출력**(418bde81c27b9c91295e53dfda2bc989be8ef174)
  - 투자 중인 금액 및 변화율 출력
- **일부 스타일 조정**(700d5bda46405de7640d824f2bfb0d0f7494b2bb)
<img width="1312" alt="스크린샷 2025-03-04 17 15 03" src="https://github.com/user-attachments/assets/c3334c9a-2181-4dce-b08b-2211cf6f47e1" />