### PR TITLE
Fix: 차트 미지원 종목 화면 접속 시 오류 해결

### DIFF
--- a/src/components/stocks/StockHeader.jsx
+++ b/src/components/stocks/StockHeader.jsx
@@ -32,11 +32,17 @@ const StockHeader = ({ stock, currentPrice, yesterdayData }) => {
       </StockInfo>
       <StockPrice>
         <CurrentPrice>{currentPrice.toLocaleString()}원</CurrentPrice>
-        <PriceText>{formatDate(yesterdayData.date)}보다</PriceText>
-        <PriceChange $change={change}>
-          {change > 0 ? `+${change.toLocaleString()}` : change.toLocaleString()}
-          원 ({changeRate.toFixed(2)}%)
-        </PriceChange>
+        {Object.keys(yesterdayData).length > 0 && (
+          <>
+            <PriceText>{formatDate(yesterdayData.date)}보다</PriceText>
+            <PriceChange $change={change}>
+              {change > 0
+                ? `+${change.toLocaleString()}`
+                : change.toLocaleString()}
+              원 ({changeRate.toFixed(2)}%)
+            </PriceChange>
+          </>
+        )}
       </StockPrice>
     </StockHeaderContainer>
   );

--- a/src/pages/Stocks.jsx
+++ b/src/pages/Stocks.jsx
@@ -42,7 +42,9 @@ const Stocks = () => {
           stockCode: stock.stockCode,
           period: "DAILY",
         });
-        setYesterdayData(response.data[response.data.length - 2]);
+        if (response.data.length >= 2) {
+          setYesterdayData(response.data[response.data.length - 2]);
+        }
       } catch (error) {
         console.error("주식 차트 데이터 가져오기 실패:", error.message);
         setError(error);


### PR DESCRIPTION
## 배경
- 차트 미지원 종목 화면 접속 시 에러 발생
- 차트 값을 출력값으로 사용한 것이 원인

## 작업 사항
- **빈 배열 반환 시 조건 추가**(e0dfa2928d84ef7221b79361bcaea259d664ce35)
- **조건부 UI 렌더링**(46f0b2b1869089a55c543b9a669f0da9762836f6)
