### PR TITLE
Fix: 계좌 초기화 시 미출력 및 계좌 기록 잔액 출력 수정

### DIFF
--- a/src/components/account/AccountRecords.jsx
+++ b/src/components/account/AccountRecords.jsx
@@ -48,7 +48,7 @@ const AccountRecords = () => {
           <RecordTheadTr>
             <RecordTheadTh style={{ width: "5%" }} />
             <RecordTheadTh style={{ width: "30%", justifyContent: "start" }}>
-              일시
+              생성 일시
             </RecordTheadTh>
             <RecordTheadTh style={{ width: "30%" }}>최종 잔고</RecordTheadTh>
             <RecordTheadTh style={{ width: "30%" }}>수익률</RecordTheadTh>
@@ -57,9 +57,13 @@ const AccountRecords = () => {
         </RecordThead>
         <RecordTableContent>
           {accountRecords.reverse().map((el, index) => {
-            const formattedBalance = el.balance.toLocaleString();
+            const formattedBalance = (
+              el.balance + el.totalEvaluatedAmount
+            ).toLocaleString();
 
-            const change = ((el.balance - 10000000) / 10000000) * 100;
+            const change =
+              ((el.balance + el.totalEvaluatedAmount - 10000000) / 10000000) *
+              100;
             return (
               <RecordTableAccount key={el.id} $isOdd={(index + 1) % 2 !== 0}>
                 <AccountNumber>{index + 1}</AccountNumber>

--- a/src/components/account/CurrentAccount.jsx
+++ b/src/components/account/CurrentAccount.jsx
@@ -54,8 +54,7 @@ const CurrentAccount = () => {
     }
 
     try {
-      const response = await createAccount();
-      console.log(response);
+      await createAccount();
     } catch (error) {
       if (error.code === "4003") {
         alert(error.message);
@@ -79,8 +78,6 @@ const CurrentAccount = () => {
     ? ((balanceChange / previousBalance) * 100).toFixed(2)
     : "0.00";
 
-  console.log(accountProfits);
-
   useEffect(() => {
     fetchCurrentAccount();
   }, []);
@@ -97,7 +94,12 @@ const CurrentAccount = () => {
             초기화 및 계좌 재생성
           </CreateAccountBtn>
         </BalanceHeader>
-        <Balance>{accountProfits[0].totalBalance.toLocaleString()} 원</Balance>
+        <Balance>
+          {accountProfits[0]?.totalBalance
+            ? accountProfits[0].totalBalance.toLocaleString()
+            : currentAccount.balance.toLocaleString()}{" "}
+          원
+        </Balance>
         {hasEnoughData ? (
           <BalanceChange>
             이 전날보다{" "}
@@ -121,7 +123,7 @@ const CurrentAccount = () => {
           <AvailableBalance>
             {currentAccount.totalEvaluatedAmount.toLocaleString()}원
             <Return $return={currentAccount.totalProfitAmount}>
-              {currentAccount.totalProfitAmount > 0
+              {currentAccount.totalProfitAmount >= 0
                 ? `+ ${currentAccount.totalProfitAmount.toLocaleString()}`
                 : `- ${Math.abs(
                     currentAccount.totalProfitAmount


### PR DESCRIPTION
## 배경
- 주말에 계좌 초기화 시 기록 없음으로 인한 페이지 미출력 현상 발견
- 전체 계좌 기록에서 최종 주문 가능 금액만 출력되는 현상 발견

## 작업 사항
- **주말 내 계좌 초기화 후 자산 화면 출력**(0bff0ed42956db567b59cf57959125a1cd39d8ae)
  - `accountProfits`가 빈 배열일 경우 조건 추가
- **전체 계좌 기록 최종 잔고 조건 변경**(d491280d48a75ad0ba5634acd31ed36df2444052)
  - `주문 가능 금액 + 평가금` 을 출력하도록 변경
