### PR TITLE
Fix: 차트 미지원 종목 거래 방지

### DIFF
--- a/src/components/stocks/StockTrade.jsx
+++ b/src/components/stocks/StockTrade.jsx
@@ -7,7 +7,7 @@ import PropTypes from "prop-types";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
 
-const StockTrade = ({ stock, currentPrice }) => {
+const StockTrade = ({ stock, currentPrice, chartData }) => {
   const { user } = useAuth();
   const [tradeType, setTradeType] = useState("BUY");
   const [priceType, setPriceType] = useState("지정가");
@@ -259,6 +259,7 @@ const StockTrade = ({ stock, currentPrice }) => {
           type="submit"
           onClick={handleSubmit}
           disabled={
+            chartData.length <= 0 ||
             !user ||
             !isTradingTime() ||
             (tradeTypes[activeTradeIndex].label === "판매" &&
@@ -267,7 +268,9 @@ const StockTrade = ({ stock, currentPrice }) => {
           $color={tradeTypes[activeTradeIndex].color}
           $hoverColor={tradeTypes[activeTradeIndex].hoverColor}
         >
-          {!user
+          {chartData.length <= 0
+            ? "거래 불가능한 종목입니다."
+            : !user
             ? `로그인하고 ${tradeTypes[activeTradeIndex].label}하기`
             : !isTradingTime()
             ? `주문 가능 시간(9:00 ~ 15:30)`
@@ -308,6 +311,7 @@ StockTrade.propTypes = {
     stockCode: PropTypes.string.isRequired,
   }),
   currentPrice: PropTypes.number.isRequired,
+  chartData: PropTypes.array.isRequired,
 };
 
 export default StockTrade;

--- a/src/pages/Stocks.jsx
+++ b/src/pages/Stocks.jsx
@@ -219,7 +219,11 @@ const Stocks = () => {
           handlePeriod={handlePeriod}
           chartData={chartData}
         />
-        <StockTrade stock={stock} currentPrice={currentPrice} />
+        <StockTrade
+          stock={stock}
+          currentPrice={currentPrice}
+          chartData={chartData}
+        />
       </StockContainer>
       <LiveStockPrice messages={messages} />
     </Container>


### PR DESCRIPTION
## 배경
- 차트 미지원 종목 거래 시 잔고는 차감되지만 보유종목에는 추가되지 않는 현상 발견

## 작업 사항
- **차트 미지원 종목 거래 방지 기능 추가**(814e9680eb61db44647803a6d3ae5180f5afaceb)
<img width="1309" alt="스크린샷 2025-03-20 10 43 34" src="https://github.com/user-attachments/assets/3ed0980c-9b83-4913-bd27-2654a5d5a03d" />
